### PR TITLE
Making MXBeanPoller a public class

### DIFF
--- a/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/MXBeanPoller.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/MXBeanPoller.java
@@ -46,7 +46,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Sensors are not required to pull data from MBeans, but are designed to do so.
  *
  */
-class MXBeanPoller {
+public class MXBeanPoller {
 
     private static final Logger log = LogManager.getLogger(MXBeanPoller.class);
 


### PR DESCRIPTION
MXBeanPoller is package-private, meaning I can't use it unless I put my stuff in `software.amazon.swage.metrics.jmx`, which I don't think was intended.