### PR TITLE
Log fatal exceptions in the scheduled metrics publisher

### DIFF
--- a/metrics-core/src/main/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorder.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorder.java
@@ -103,7 +103,7 @@ public class CloudWatchRecorder extends MetricRecorder {
         try {
             this.sendAggregatedData();
         } catch (Throwable t) {
-            log.fatal("CloudWatch recorder encountered an unrecoverable error and will stop", t);
+            log.error("CloudWatch recorder encountered an unrecoverable error and will stop", t);
             throw t;
         }
     };
@@ -246,7 +246,7 @@ public class CloudWatchRecorder extends MetricRecorder {
     }
 
     /**
-     * Single that the recorder should shutdown.
+     * Signal that the recorder should shutdown.
      * Queued up metric events will be flushed, and this method will block
      * until all pending ones are sent or it loses patience and times out.
      *

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorder.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorder.java
@@ -14,7 +14,6 @@
  */
 package software.amazon.swage.metrics.record.cloudwatch;
 
-import com.amazonaws.services.cloudwatch.model.AmazonCloudWatchException;
 import software.amazon.swage.collection.TypedMap;
 import software.amazon.swage.metrics.ContextData;
 import software.amazon.swage.metrics.Metric;
@@ -109,6 +108,70 @@ public class CloudWatchRecorder extends MetricRecorder {
 
     private final MetricDataAggregator aggregator;
 
+    public static final class Builder {
+        private String namespace;
+        private boolean autoShutdown = false;
+        private AmazonCloudWatch client = AmazonCloudWatchClientBuilder.defaultClient();
+        private DimensionMapper dimensionMapper = DEFAULT_DIMENSIONS;
+        private int maxJitter = DEFAULT_JITTER;
+        private int publishFrequency = DEFAULT_PUBLISH_FREQ;
+        private ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+
+        public Builder namespace(String namespace) {
+            this.namespace = namespace;
+            return this;
+        }
+
+        public Builder dimensionMapper(DimensionMapper dimensionMapper) {
+            this.dimensionMapper = dimensionMapper;
+            return this;
+        }
+
+        public Builder client(AmazonCloudWatch client) {
+            this.client = client;
+            return this;
+        }
+
+        public Builder maxJitter(int maxJitter) {
+            this.maxJitter = maxJitter;
+            return this;
+        }
+
+        public Builder publishFrequency(int publishFrequency) {
+            this.publishFrequency = publishFrequency;
+            return this;
+        }
+
+        public Builder autoShutdown(boolean autoShutdown) {
+            this.autoShutdown = autoShutdown;
+            return this;
+        }
+
+        public Builder scheduledExecutorService(ScheduledExecutorService scheduledExecutorService) {
+            this.scheduledExecutorService = scheduledExecutorService;
+            return this;
+        }
+
+        public CloudWatchRecorder build() {
+            CloudWatchRecorder recorder = new CloudWatchRecorder(
+                    client,
+                    namespace,
+                    maxJitter,
+                    publishFrequency,
+                    dimensionMapper,
+                    scheduledExecutorService
+            );
+
+            if (this.autoShutdown) {
+                Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                    recorder.shutdown();
+                }));
+            }
+
+            return recorder;
+        }
+    }
+
     /**
      * Convenience factory method to create a CloudWatchRecorder and register a JVM
      * shutdown hook to automatically shut it down on application exit.
@@ -118,11 +181,16 @@ public class CloudWatchRecorder extends MetricRecorder {
      *
      * @param namespace CloudWatch namespace to publish under.
      * @return A CloudWatchRecorder instance that will automatically shutdown on JVM exit.
+     * @deprecated Use {@link CloudWatchRecorder.Builder} instead
      */
+    @Deprecated
     public static final CloudWatchRecorder withAutoShutdown(
             final String namespace)
     {
-        return withAutoShutdown(namespace, DEFAULT_DIMENSIONS);
+        return new Builder()
+                .autoShutdown(true)
+                .namespace(namespace)
+                .build();
     }
 
     /**
@@ -135,23 +203,18 @@ public class CloudWatchRecorder extends MetricRecorder {
      * @param dimensionMapper Configuration specifying which dimensions to sent
      *                        to CloudWatch for each metric event.
      * @return A CloudWatchRecorder instance that will automatically shutdown on JVM exit.
+     * @deprecated Use {@link CloudWatchRecorder.Builder} instead
      */
+    @Deprecated
     public static final CloudWatchRecorder withAutoShutdown(
             final String namespace,
             final DimensionMapper dimensionMapper)
     {
-        CloudWatchRecorder recorder = new CloudWatchRecorder(
-                AmazonCloudWatchClientBuilder.defaultClient(),
-                namespace,
-                DEFAULT_JITTER,
-                DEFAULT_PUBLISH_FREQ,
-                dimensionMapper);
-
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            recorder.shutdown();
-        }));
-
-        return recorder;
+        return new Builder()
+                .autoShutdown(true)
+                .namespace(namespace)
+                .dimensionMapper(dimensionMapper)
+                .build();
     }
 
     /**
@@ -168,7 +231,9 @@ public class CloudWatchRecorder extends MetricRecorder {
      *
      * @param client Client to use for connecting to CloudWatch
      * @param namespace CloudWatch namespace to publish under
+     * @deprecated Use {@link CloudWatchRecorder.Builder} instead
      */
+    @Deprecated
     public CloudWatchRecorder(
             final AmazonCloudWatch client,
             final String namespace)
@@ -196,13 +261,54 @@ public class CloudWatchRecorder extends MetricRecorder {
      *                         Suggested value of 60, for one minute aggregation.
      * @param dimensionMapper Configuration specifying which dimensions to sent
      *                        to CloudWatch for each metric event.
+     * @deprecated Use {@link CloudWatchRecorder.Builder} instead
      */
+    @Deprecated
     public CloudWatchRecorder(
             final AmazonCloudWatch client,
             final String namespace,
             final int maxJitter,
             final int publishFrequency,
-            final DimensionMapper dimensionMapper)
+            final DimensionMapper dimensionMapper) {
+        this(
+                client,
+                namespace,
+                maxJitter,
+                publishFrequency,
+                dimensionMapper,
+                Executors.newSingleThreadScheduledExecutor()
+        );
+    }
+
+    /**
+     * Create a new recorder instance.
+     * This recorder will periodically send aggregated metric events to CloudWatch
+     * via the provided client. Requests will be queued and sent using a
+     * single-threaded ScheduledExecutorService every publishFrequency (in seconds).
+     * The initial submission to CloudWatch will be delayed by a random amount
+     * on top of the publish frequency, bounded by maxJitter.
+     *
+     * The {@link #shutdown} method must be called when the application is done
+     * with the recorder in order to flush and stop the reporting thread.
+     *
+     * @param client Client to use for connecting to CloudWatch
+     * @param namespace CloudWatch namespace to publish under
+     * @param maxJitter Maximum delay before counting publish frequency for
+     *                  initial request, in seconds.
+     *                  A value of 0 will provide no jitter.
+     * @param publishFrequency Batch up and publish at this interval, in seconds.
+     *                         Suggested value of 60, for one minute aggregation.
+     * @param dimensionMapper Configuration specifying which dimensions to sent
+     *                        to CloudWatch for each metric event.
+     * @param scheduledExecutorService Executor to schedule metric publishing at a fixed rate.
+     */
+    private CloudWatchRecorder(
+            final AmazonCloudWatch client,
+            final String namespace,
+            final int maxJitter,
+            final int publishFrequency,
+            final DimensionMapper dimensionMapper,
+            final ScheduledExecutorService scheduledExecutorService)
     {
         if (client == null) {
             throw new IllegalArgumentException("AmazonCloudWatch must be provided");
@@ -216,10 +322,7 @@ public class CloudWatchRecorder extends MetricRecorder {
 
         this.metricsClient = client;
         this.namespace = namespace;
-
-        //TODO: is there value in injecting this? Yes, but then how to handle lifecycle?
-        this.publishExecutor = Executors.newSingleThreadScheduledExecutor();
-
+        this.publishExecutor = scheduledExecutorService;
         this.aggregator = new MetricDataAggregator(dimensionMapper);
 
         start(maxJitter, publishFrequency);
@@ -372,13 +475,7 @@ public class CloudWatchRecorder extends MetricRecorder {
         PutMetricDataRequest request = new PutMetricDataRequest();
         request.setNamespace( namespace );
         request.setMetricData( metricData );
-
-        try {
-            metricsClient.putMetricData( request );
-        } catch (AmazonCloudWatchException e) {
-            // log and do nothing
-            log.error("Unable to publish metrics. CloudWatch recorder encountered an error", e);
-        }
+        metricsClient.putMetricData( request );
     }
 
 }

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorderTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorderTest.java
@@ -97,7 +97,13 @@ public class CloudWatchRecorderTest {
 
         final AmazonCloudWatch client = mock(AmazonCloudWatch.class);
 
-        final CloudWatchRecorder recorder = new CloudWatchRecorder(client, namespace, 60, 120, mapper);
+        final CloudWatchRecorder recorder = new CloudWatchRecorder.Builder()
+                .client(client)
+                .namespace(namespace)
+                .publishFrequency(120)
+                .maxJitter(60)
+                .dimensionMapper(mapper)
+                .build();
 
         final MetricRecorder.Context context = recorder.context(data);
         context.record(M_TIME, time, Unit.MILLISECOND, Instant.now());
@@ -129,7 +135,13 @@ public class CloudWatchRecorderTest {
         CloudWatchRecorder recorder = null;
         try {
             // no jitter, publish soon
-            recorder = new CloudWatchRecorder(client, namespace, 0, 1, mapper);
+            recorder = new CloudWatchRecorder.Builder()
+                    .client(client)
+                    .namespace(namespace)
+                    .maxJitter(0)
+                    .publishFrequency(1)
+                    .dimensionMapper(mapper)
+                    .build();
 
             final TypedMap data = ContextData.withId(id).build();
             final MetricRecorder.Context context = recorder.context(data);
@@ -197,7 +209,13 @@ public class CloudWatchRecorderTest {
         CloudWatchRecorder recorder = null;
         try {
             // no jitter, publish soon
-            recorder = new CloudWatchRecorder(client, namespace, 0, 1, mapper);
+            recorder = new CloudWatchRecorder.Builder()
+                    .client(client)
+                    .namespace(namespace)
+                    .maxJitter(0)
+                    .publishFrequency(1)
+                    .dimensionMapper(mapper)
+                    .build();
 
             final TypedMap data = ContextData.withId(id).build();
             final MetricRecorder.Context context = recorder.context(data);


### PR DESCRIPTION
The `CloudWatchRecorder` schedules a task to publish metrics periodically
which will die silently if it encounters an exception. This catches and
logs that exception.