### PR TITLE
Provide a Child context mechanism for MetricRecorder.Context

### DIFF
--- a/metrics-api/src/main/java/software/amazon/swage/metrics/DynamicContextData.java
+++ b/metrics-api/src/main/java/software/amazon/swage/metrics/DynamicContextData.java
@@ -1,0 +1,24 @@
+package software.amazon.swage.metrics;
+
+import software.amazon.swage.collection.ImmutableTypedMap;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Builder for data carried with the context under which a metric is reported.
+ *
+ * <p>
+ * This builder allows for regular state-based equality semantics.
+ *
+ * <p>
+ * Built instances are immutable.  Metric recording will use
+ * the data across threads as needed, and relies on the data being
+ * unchanged for a particular Context.
+ *
+ * <p>
+ */
+public class DynamicContextData extends ImmutableTypedMap.Builder {
+    public DynamicContextData() {
+        super(new ConcurrentHashMap<>());
+    }
+}

--- a/type-safe/src/main/java/software/amazon/swage/collection/ImmutableTypedMap.java
+++ b/type-safe/src/main/java/software/amazon/swage/collection/ImmutableTypedMap.java
@@ -21,6 +21,7 @@ import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -129,7 +130,11 @@ public final class ImmutableTypedMap implements TypedMap {
         private final Map<Key<?>, Entry<?>> dataMap;
 
         protected Builder() {
-            this.dataMap = new IdentityHashMap<>();
+            this(new IdentityHashMap<>());
+        }
+
+        protected Builder(final Map<Key<?>, Entry<?>> map) {
+            this.dataMap = Objects.requireNonNull(map);
         }
 
         public static Builder from(TypedMap data) {

--- a/type-safe/src/main/java/software/amazon/swage/collection/TypedMap.java
+++ b/type-safe/src/main/java/software/amazon/swage/collection/TypedMap.java
@@ -17,6 +17,7 @@ package software.amazon.swage.collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
@@ -108,6 +109,20 @@ public interface TypedMap extends Iterable<TypedMap.Entry> {
          */
         public String toString() {
             return name;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            final Key<?> key = (Key<?>) o;
+            return Objects.equals(name, key.name) &&
+                    Objects.equals(valueType, key.valueType);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, valueType);
         }
     }
 

--- a/type-safe/src/test/java/software/amazon/swage/collection/TypedMapKeyTest.java
+++ b/type-safe/src/test/java/software/amazon/swage/collection/TypedMapKeyTest.java
@@ -1,0 +1,61 @@
+package software.amazon.swage.collection;
+
+import org.junit.Test;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class TypedMapKeyTest {
+
+    @Test
+    public void correctlyImplementsHashCode() {
+        final String keyName = UUID.randomUUID().toString();
+        final TypedMap.Key<String> key = TypedMap.key(keyName, String.class);
+
+        // Test 1: Hashcode is deterministic and reflexive
+        assertEquals(key.hashCode(), key.hashCode());
+
+        // Test 2: Hashcode is determined by name and class
+        assertEquals(Objects.hash(key.name, key.valueType), key.hashCode());
+
+        // Test 3: two objects with the same values have same hash
+        final TypedMap.Key<String> same = TypedMap.key(keyName, String.class);
+        assertEquals(key.hashCode(), same.hashCode());
+        assertEquals(same.hashCode(), key.hashCode());
+
+        // Test 4: two objects with different values do not have same hash
+        final String another = UUID.randomUUID().toString();
+        final TypedMap.Key<String> different = TypedMap.key(another, String.class);
+        final TypedMap.Key<Object> differentValue = TypedMap.key(keyName, Object.class);
+        assertNotEquals(different.hashCode(), key.hashCode());
+        assertNotEquals(differentValue.hashCode(), key.hashCode());
+    }
+
+    @Test
+    public void correctlyImplementsEquals() {
+        final String keyName = UUID.randomUUID().toString();
+        final TypedMap.Key<String> key = TypedMap.key(keyName, String.class);
+
+        // Test 1: equals is deterministic and reflexive
+        assertEquals(key, key);
+
+        // Test2: is not equal to null or random Object
+        assertNotEquals(null, key);
+        assertNotEquals(new Object(), key);
+
+        // Test 3: two objects with the same values are equals
+        final TypedMap.Key<String> same = TypedMap.key(keyName, String.class);
+        assertEquals(key, same);
+        assertEquals(same, key);
+
+        // Test 4: two objects with different values are not equal
+        final String another = UUID.randomUUID().toString();
+        final TypedMap.Key<String> different = TypedMap.key(another, String.class);
+        final TypedMap.Key<Object> differentValue = TypedMap.key(keyName, Object.class);
+        assertNotEquals(different, key);
+        assertNotEquals(differentValue, key);
+    }
+}


### PR DESCRIPTION
To enable libraries to create childContext that can override existing keys, this change implements `equals()` and `hashCode()` on `TypedMap.Key`, then implements `childContext(TypedMap another)` in `MetricRecorder.Context`.

When `childContext(TypedMap another)` is called, we want to be able to merge the Key/Value of `another` with the values in the current Context and produce a new Context. 

The current implementation of TypedMap.Key prevents a successful comparison in this scenario because it relies on reference-based equality. This pull request implements state-based equality and the ability to construct a child MetricRecorder.Context from another input TypedMap, where that map is merged with the map of the current Context.