### PR TITLE
[metrics] Pass entire Context to recorder rather than just the metadata.

### DIFF
--- a/metrics-api/src/main/java/software/amazon/swage/metrics/ContextData.java
+++ b/metrics-api/src/main/java/software/amazon/swage/metrics/ContextData.java
@@ -18,7 +18,7 @@ import software.amazon.swage.collection.ImmutableTypedMap;
 import software.amazon.swage.collection.TypedMap;
 
 /**
- * Builder for data carried with the context under which a metric is reported.
+ * Builder for metadata carried with the context under which a metric is reported.
  *
  * <p>
  * Roughly equivalent to a request context, this is the metadata associated with
@@ -27,14 +27,14 @@ import software.amazon.swage.collection.TypedMap;
  *
  * <p>
  * Built instances are immutable.  Metric recording will use
- * the data across threads as needed, and relies on the data being
+ * the metadata across threads as needed, and relies on the metadata being
  * unchanged for a particular Context.
  *
  * <p>
  * Different application domains may extend the builder to facilitate adding
- * the appropriate data.
+ * the appropriate metadata.
  *
- * A domain-specific data builder might look like:
+ * A domain-specific metadata builder might look like:
  * <pre>{@code
 public class DomainSpecificData extends ContextData {
     public static final TypedMap.Key<String> MARKETPLACE = TypedMap.key("marketplace", String.class);
@@ -42,9 +42,9 @@ public class DomainSpecificData extends ContextData {
     public static final TypedMap.Key<String> OPERATION   = TypedMap.key("operation", String.class);
     public static final TypedMap.Key<String> PROGRAM     = TypedMap.key("programName", String.class);
 
-    public static DomainSpecificData from(TypedMap data) {
+    public static DomainSpecificData from(TypedMap metadata) {
         DomainSpecificData b = new DomainSpecificData();
-        data.iterator().forEachRemaining((e) -> b.add(e.getKey(), e));
+        metadata.iterator().forEachRemaining((e) -> b.add(e.getKey(), e));
         return b;
     }
 

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/MultiRecorder.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/MultiRecorder.java
@@ -14,8 +14,6 @@
  */
 package software.amazon.swage.metrics;
 
-import software.amazon.swage.collection.TypedMap;
-
 import java.time.Instant;
 import java.util.List;
 
@@ -37,7 +35,7 @@ public class MultiRecorder extends MetricRecorder {
             final Number value,
             final Unit unit,
             final Instant timestamp,
-            final TypedMap context)
+            final Context context)
     {
         //TODO: something smarter, or at least call out ordered iterated nature
         for (MetricRecorder r : recorders) {
@@ -46,7 +44,7 @@ public class MultiRecorder extends MetricRecorder {
     }
 
     @Override
-    protected void count(final Metric label, final long delta, final TypedMap context) {
+    protected void count(final Metric label, final long delta, final Context context) {
         for (MetricRecorder r : recorders) {
             r.count(label, delta, context);
         }

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/StandardContext.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/StandardContext.java
@@ -17,7 +17,7 @@ package software.amazon.swage.metrics;
 import software.amazon.swage.collection.TypedMap;
 
 /**
- * Metric context builder with keys for data that is common across many
+ * Metric context builder with keys for metadata that is common across many
  * different applications.
  *
  */

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/MXBeanPoller.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/MXBeanPoller.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Provides MBeans integration for metrics, polling a set of M(X)Beans and
- * sending data to the configured metric sink.
+ * sending metadata to the configured metric sink.
  * This provides a mechanism to expose periodic health and utilization statistics in your
  * standard metrics logging.
  *
@@ -43,7 +43,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * interval and record the measurements.  Each Sensor is associated with an
  * MBean, specialized to read and interpret the values on the bean.
  *
- * Sensors are not required to pull data from MBeans, but are designed to do so.
+ * Sensors are not required to pull metadata from MBeans, but are designed to do so.
  *
  */
 public class MXBeanPoller {
@@ -162,7 +162,7 @@ public class MXBeanPoller {
 
     private void runSensors() {
 
-        //TODO: should there be per-emit context data?
+        //TODO: should there be per-emit context metadata?
         //TODO: or should we have one Context and only close at the very end?
         MetricRecorder.Context metricContext = metricRecorder.context(this.updaterContext);
 

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/sensor/Sensor.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/sensor/Sensor.java
@@ -18,7 +18,7 @@ import software.amazon.swage.collection.TypedMap;
 import software.amazon.swage.metrics.MetricRecorder;
 
 /**
- * Pull data of one particular type from one particular M(X)Bean and send to a
+ * Pull metadata of one particular type from one particular M(X)Bean and send to a
  * MetricRecorder.
  *
  * Sensors are not required to be thread safe.
@@ -26,13 +26,13 @@ import software.amazon.swage.metrics.MetricRecorder;
 public interface Sensor {
 
     /**
-     * Add any additional context data to the existing context, return a new
-     * instance of context data.  Implementations that have no data to add
+     * Add any additional context metadata to the existing context, return a new
+     * instance of context metadata.  Implementations that have no metadata to add
      * return the existing context unchanged.
      *
-     * @param existing Context data already known
+     * @param existing Context metadata already known
      * @return A TypedMap containing all entries of the existing context with
-     *         sensor-specific data added
+     *         sensor-specific metadata added
      */
     default public TypedMap addContext(final TypedMap existing)
     {
@@ -44,7 +44,7 @@ public interface Sensor {
      * results to {@code metrics}.  Must NOT close the {@code Context} object as other
      * {@code Sensor} may also contribute to it.
      *
-     * @param metricContext Metrics context which will be used to record data
+     * @param metricContext Metrics context which will be used to record metadata
      * @throws SenseException When a problem occurred collecting measurements
      */
     public void sense(final MetricRecorder.Context metricContext) throws SenseException;

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/record/MemoryRecorder.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/record/MemoryRecorder.java
@@ -1,0 +1,55 @@
+package software.amazon.swage.metrics.record;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import software.amazon.swage.metrics.Metric;
+import software.amazon.swage.metrics.MetricRecorder;
+import software.amazon.swage.metrics.Unit;
+
+/**
+ *
+ */
+public class MemoryRecorder extends MetricRecorder {
+    // Helper to represent a metric event, for ease comparing input and output
+    public static class Event {
+        public final Metric metric;
+        public final Number value;
+        public final Unit unit;
+        public final Instant timestamp;
+        public final Context context;
+
+        private Event(Metric metric, Number value, Unit unit, Instant timestamp, Context context) {
+            this.metric = metric;
+            this.value = value;
+            this.unit = unit;
+            this.timestamp = timestamp;
+            this.context = context;
+        }
+
+        private Event(Metric name, long delta, Context context) {
+            this.metric = name;
+            this.value = Long.valueOf(delta);
+            this.unit = Unit.NONE;
+            this.timestamp = null;
+            this.context = context;
+        }
+    }
+
+    private final List<Event> output = new ArrayList<>();
+
+    @Override
+    protected void record(Metric label, Number value, Unit unit, Instant time, Context context) {
+        output.add(new Event(label, value, unit, time, context));
+    }
+
+    @Override
+    protected void count(Metric metric, long delta, Context context) {
+        output.add(new Event(metric, delta, context));
+    }
+
+    public List<Event> output() {
+        return output;
+    }
+}

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorder.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorder.java
@@ -14,20 +14,6 @@
  */
 package software.amazon.swage.metrics.record.cloudwatch;
 
-import software.amazon.swage.collection.TypedMap;
-import software.amazon.swage.metrics.ContextData;
-import software.amazon.swage.metrics.Metric;
-import software.amazon.swage.metrics.MetricRecorder;
-import software.amazon.swage.metrics.Unit;
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
-import com.amazonaws.services.cloudwatch.model.MetricDatum;
-import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
-import com.amazonaws.services.cloudwatch.model.StandardUnit;
-import com.amazonaws.services.cloudwatch.model.StatisticSet;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
@@ -38,6 +24,19 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
+import com.amazonaws.services.cloudwatch.model.StandardUnit;
+import com.amazonaws.services.cloudwatch.model.StatisticSet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.swage.metrics.ContextData;
+import software.amazon.swage.metrics.Metric;
+import software.amazon.swage.metrics.MetricRecorder;
+import software.amazon.swage.metrics.Unit;
 
 /**
  * MetricRecorder that sends all metric events to CloudWatch.
@@ -279,7 +278,7 @@ public class CloudWatchRecorder extends MetricRecorder {
             final Number value,
             final Unit unit,
             final Instant time,
-            final TypedMap context)
+            final Context context)
     {
         if (!running.get()) {
             log.debug("record called on shutdown recorder");
@@ -291,14 +290,14 @@ public class CloudWatchRecorder extends MetricRecorder {
         // event lost. Rather than having one timestamp apply to all, we just
         // drop the time information and use the timestamp of aggregation.
 
-        aggregator.add(context,
+        aggregator.add(context.metadata(),
                        label,
                        value.doubleValue(),
                        unitMapping.get(unit));
     }
 
     @Override
-    public void count(final Metric label, final long delta, final TypedMap context)
+    public void count(final Metric label, final long delta, final Context context)
     {
         if (!running.get()) {
             log.debug("count called on shutdown recorder");
@@ -306,7 +305,7 @@ public class CloudWatchRecorder extends MetricRecorder {
             return;
         }
 
-        aggregator.add(context,
+        aggregator.add(context.metadata(),
                        label,
                        Long.valueOf(delta).doubleValue(),
                        StandardUnit.Count);
@@ -345,14 +344,14 @@ public class CloudWatchRecorder extends MetricRecorder {
 
     private void sendAggregatedData() {
 
-        // Grab all the current aggregated data, resetting
+        // Grab all the current aggregated metadata, resetting
         // the aggregator to empty in the process
         List<MetricDatum> metricData = aggregator.flush();
         if(metricData.isEmpty()) {
             return;
         }
 
-        // Send the data in batches to adhere to CloudWatch limitation on the
+        // Send the metadata in batches to adhere to CloudWatch limitation on the
         // number of MetricDatum objects per request, see:
         // http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_limits.html
         int begin = 0;

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/record/cloudwatch/DimensionMapper.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/record/cloudwatch/DimensionMapper.java
@@ -47,7 +47,7 @@ import java.util.Set;
  * does a lookup based on the stored information.  Ideally every event recorded
  * would send with it all available context information, and a separate system
  * (perhaps CloudWatch, perhaps something sitting in front) would allow those
- * consuming the data to filter as needed.
+ * consuming the metadata to filter as needed.
  *
  * A DimensionMapper should be configured at application startup/configuration,
  * like:
@@ -118,7 +118,7 @@ public class DimensionMapper {
     }
 
     /**
-     * Pull desired info out of the metric context data and convert to
+     * Pull desired info out of the metric context metadata and convert to
      * CloudWatch {@link Dimension} objects, according to the filter mapping
      * defined.
      *
@@ -126,7 +126,7 @@ public class DimensionMapper {
      * the dimension will be added with a value of "null".
      *
      * @param metric Metric being sent
-     * @param context TypedMap containing metric context data
+     * @param context TypedMap containing metric context metadata
      * @return A list of Dimensions appropriate to send to CloudWatch
      */
     public List<Dimension> getDimensions(final Metric metric, final TypedMap context)

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/record/cloudwatch/MetricDataAggregator.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/record/cloudwatch/MetricDataAggregator.java
@@ -34,12 +34,12 @@ import java.util.concurrent.ConcurrentHashMap;
  * {@link MetricDatum} appropriate to send to CloudWatch.
  *
  * Allows adding metrics for a period of time, then flushing all the aggregated
- * data, then accumulating more.
+ * metadata, then accumulating more.
  * <p>
  * Package-private as this is intended purely as an implementation detail of
  * the CloudWatchRecorder. The implementation is specific to how it is used
  * by the recorder, and does not currently support "general purpose"
- * aggregation of metric data/MetricDatums.
+ * aggregation of metric metadata/MetricDatums.
  * <p>
  * Metrics are aggregated by namespace, metricName, dimensions, and unit.
  * Matching metrics events will be added together to form a single
@@ -66,7 +66,7 @@ class MetricDataAggregator {
     /**
      * Add a metric event to be aggregated.
      * Events with the same name, unit, and dimensions will have their values
-     * aggregated into {@link StatisticSet}s, with the aggregated data
+     * aggregated into {@link StatisticSet}s, with the aggregated metadata
      * available via {@link #flush}.
      *
      * @param context Metric context to use for dimension information
@@ -97,15 +97,15 @@ class MetricDataAggregator {
     /**
      * Flush all the current aggregated MetricDatum and return as a list.
      * This is safe to call concurrently with {@link #add}.
-     * All data added prior to a flush call will be included in the returned aggregate.
-     * Any data added after the flush call returns will be included in a subsequent flush.
+     * All metadata added prior to a flush call will be included in the returned aggregate.
+     * Any metadata added after the flush call returns will be included in a subsequent flush.
      * Data added while a flush call is processing may be included in the current flush
      * or a subsequent flush, but will not be included twice.
      *
-     * The timestamp on the aggregated data will be the time it was flushed,
+     * The timestamp on the aggregated metadata will be the time it was flushed,
      * not the time of any of the original metric events.
      *
-     * @return list of all data aggregated since the last flush
+     * @return list of all metadata aggregated since the last flush
      */
     public List<MetricDatum> flush() {
         if (statisticsMap.size() == 0) {
@@ -116,7 +116,7 @@ class MetricDataAggregator {
         // at this time in the statisticsMap.
         // Note that this iterates over the key set of the underlying map, and
         // removes keys from the map at the same time. It is possible keys may
-        // be added during this iteration, or data for keys modified between
+        // be added during this iteration, or metadata for keys modified between
         // a key being chosen for iteration and being removed from the map.
         // This is ok.  Any new keys will be picked up on subsequent flushes.
         //TODO: use two maps and swap between, to ensure 'perfect' segmentation?

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/record/file/FileRecorder.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/record/file/FileRecorder.java
@@ -14,13 +14,6 @@
  */
 package software.amazon.swage.metrics.record.file;
 
-import software.amazon.swage.collection.TypedMap;
-import software.amazon.swage.metrics.Metric;
-import software.amazon.swage.metrics.MetricRecorder;
-import software.amazon.swage.metrics.Unit;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Path;
@@ -30,10 +23,17 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.swage.collection.TypedMap;
+import software.amazon.swage.metrics.Metric;
+import software.amazon.swage.metrics.MetricRecorder;
+import software.amazon.swage.metrics.Unit;
+
 /**
  * Simple MetricRecorder that sends metrics events to a file.
  *
- * The data will be written to a file with the current time slice appended to
+ * The metadata will be written to a file with the current time slice appended to
  * the end of the name, and periodically rolled over to a new file.
  *
  * This implementation is bare-bones, and does not serialize to any
@@ -128,7 +128,7 @@ public class FileRecorder extends MetricRecorder {
             final Number value,
             final Unit unit,
             final Instant timestamp,
-            final TypedMap context)
+            final Context context)
     {
         if (!running.get()) {
             log.debug("record called on shutdown recorder");
@@ -139,7 +139,7 @@ public class FileRecorder extends MetricRecorder {
         StringBuilder sb = new StringBuilder();
         sb.append("metric=")
           .append(label.toString());
-        serializeContext(sb, context);
+        serializeContext(sb, context.metadata());
         sb.append(":")
           .append(String.valueOf(value))
           .append(unit.toString())
@@ -153,7 +153,7 @@ public class FileRecorder extends MetricRecorder {
     protected void count(
             final Metric label,
             final long delta,
-            final TypedMap context)
+            final Context context)
     {
         if (!running.get()) {
             log.debug("count called on shutdown recorder");
@@ -164,7 +164,7 @@ public class FileRecorder extends MetricRecorder {
         StringBuilder sb = new StringBuilder();
         sb.append("metric=")
           .append(label.toString());
-        serializeContext(sb, context);
+        serializeContext(sb, context.metadata());
         sb.append(":count:")
           .append(delta)
           .append('\n');

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/jmx/MXBeanPollerTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/jmx/MXBeanPollerTest.java
@@ -47,7 +47,7 @@ public class MXBeanPollerTest {
     private static final class DataMatcher implements ArgumentMatcher<TypedMap> {
         @Override
         public boolean matches(final TypedMap data) {
-            if (data.get(StandardContext.OPERATION) != "JMX") {
+            if (!"JMX".equals(data.get(StandardContext.OPERATION))) {
                 return false;
             }
             String id = data.get(StandardContext.ID);
@@ -64,12 +64,12 @@ public class MXBeanPollerTest {
                 final Number value,
                 final Unit unit,
                 final Instant time,
-                final TypedMap context)
+                final Context context)
         {
         }
 
         @Override
-        protected void count(final Metric label, final long delta, final TypedMap context) {
+        protected void count(final Metric label, final long delta, final Context context) {
         }
     }
 

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/MetricDataAggregatorTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/MetricDataAggregatorTest.java
@@ -65,7 +65,7 @@ public class MetricDataAggregatorTest {
         assertEquals("Metric datum has wrong stats value", Double.valueOf(value), stats.getMaximum());
         assertEquals("Metric datum has wrong stats count", Double.valueOf(1), stats.getSampleCount());
 
-        assertTrue("Flush with no data was non-empty", aggregator.flush().isEmpty());
+        assertTrue("Flush with no metadata was non-empty", aggregator.flush().isEmpty());
     }
 
 
@@ -88,7 +88,7 @@ public class MetricDataAggregatorTest {
 
         List<MetricDatum> ags = aggregator.flush();
 
-        assertEquals("Metric data hs wrong size", names.length, ags.size());
+        assertEquals("Metric metadata hs wrong size", names.length, ags.size());
         for (MetricDatum d : ags) {
             int i = 0;
             while (i < names.length && !names[i].toString().equals(d.getMetricName())) {
@@ -106,7 +106,7 @@ public class MetricDataAggregatorTest {
             assertEquals("Metric datum has wrong stats count", Double.valueOf(1), stats.getSampleCount());
         }
 
-        assertTrue("Flush with no data was non-empty", aggregator.flush().isEmpty());
+        assertTrue("Flush with no metadata was non-empty", aggregator.flush().isEmpty());
     }
 
     @Test
@@ -135,7 +135,7 @@ public class MetricDataAggregatorTest {
 
         List<MetricDatum> ags = aggregator.flush();
 
-        assertEquals("Metric data hs wrong size", 4, ags.size());
+        assertEquals("Metric metadata hs wrong size", 4, ags.size());
         boolean[] seen = {false, false, false, false};
         for (MetricDatum d : ags) {
             if (d.getMetricName().equals(A.toString()) && d.getUnit().equals(StandardUnit.Seconds.toString())) {
@@ -178,9 +178,9 @@ public class MetricDataAggregatorTest {
             assertTrue("Expected aggregated metric not seen", seen[i]);
         }
 
-        assertTrue("Flush with no data was non-empty", aggregator.flush().isEmpty());
+        assertTrue("Flush with no metadata was non-empty", aggregator.flush().isEmpty());
 
-        // Now add more data, but let's just do two this time
+        // Now add more metadata, but let's just do two this time
         for (int i=0; i<5; i++) {
             aggregator.add(context, A, i, StandardUnit.Count);
         }
@@ -193,7 +193,7 @@ public class MetricDataAggregatorTest {
 
         ags = aggregator.flush();
 
-        assertEquals("Metric data hs wrong size", 2, ags.size());
+        assertEquals("Metric metadata hs wrong size", 2, ags.size());
         boolean seenA = false;
         boolean seenO = false;
         for (MetricDatum d : ags) {
@@ -220,7 +220,7 @@ public class MetricDataAggregatorTest {
         assertTrue("Expected aggregated metric not seen", seenA);
         assertTrue("Expected aggregated metric not seen", seenO);
 
-        assertTrue("Flush with no data was non-empty", aggregator.flush().isEmpty());
+        assertTrue("Flush with no metadata was non-empty", aggregator.flush().isEmpty());
     }
 
 }

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/record/file/RollingFileWriterTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/record/file/RollingFileWriterTest.java
@@ -88,7 +88,7 @@ public class RollingFileWriterTest {
         assertEquals(null, w.getCurrentFile());
 
         // Force the writer to be created
-        w.write("some data here", 0, 0);
+        w.write("some metadata here", 0, 0);
 
         // Clean up
         w.close();
@@ -120,7 +120,7 @@ public class RollingFileWriterTest {
 
         // Set the RollingFileWriter to roll every minute
         final RollingFileWriter w = new RollingFileWriter(testDir, base, tz, true);
-        w.write("mo data mo problems", 0, 0);
+        w.write("mo metadata mo problems", 0, 0);
         w.close();
 
         // Just in case minute rolled during test, check before and after minutes


### PR DESCRIPTION
For #14, when recording a measurement pass the entire context rather than just the metadata.