### PR TITLE
Add a CloudWatchRecorder builder

### DIFF
--- a/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorderTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorderTest.java
@@ -97,7 +97,13 @@ public class CloudWatchRecorderTest {
 
         final AmazonCloudWatch client = mock(AmazonCloudWatch.class);
 
-        final CloudWatchRecorder recorder = new CloudWatchRecorder(client, namespace, 60, 120, mapper);
+        final CloudWatchRecorder recorder = new CloudWatchRecorder.Builder()
+                .client(client)
+                .namespace(namespace)
+                .publishFrequency(120)
+                .maxJitter(60)
+                .dimensionMapper(mapper)
+                .build();
 
         final MetricRecorder.Context context = recorder.context(data);
         context.record(M_TIME, time, Unit.MILLISECOND, Instant.now());
@@ -129,7 +135,13 @@ public class CloudWatchRecorderTest {
         CloudWatchRecorder recorder = null;
         try {
             // no jitter, publish soon
-            recorder = new CloudWatchRecorder(client, namespace, 0, 1, mapper);
+            recorder = new CloudWatchRecorder.Builder()
+                    .client(client)
+                    .namespace(namespace)
+                    .maxJitter(0)
+                    .publishFrequency(1)
+                    .dimensionMapper(mapper)
+                    .build();
 
             final TypedMap data = ContextData.withId(id).build();
             final MetricRecorder.Context context = recorder.context(data);
@@ -197,7 +209,13 @@ public class CloudWatchRecorderTest {
         CloudWatchRecorder recorder = null;
         try {
             // no jitter, publish soon
-            recorder = new CloudWatchRecorder(client, namespace, 0, 1, mapper);
+            recorder = new CloudWatchRecorder.Builder()
+                    .client(client)
+                    .namespace(namespace)
+                    .maxJitter(0)
+                    .publishFrequency(1)
+                    .dimensionMapper(mapper)
+                    .build();
 
             final TypedMap data = ContextData.withId(id).build();
             final MetricRecorder.Context context = recorder.context(data);


### PR DESCRIPTION
The builder allows passing in a ScheduledExecutorService for additional
control over metric publishing execution.

This replaces [pull request #5](https://github.com/awslabs/swage/pull/5) by allowing the customer to inject exception handling if they need it.

