### PR TITLE
Add childContext to MetricContext

### DIFF
--- a/metrics-api/src/main/java/software/amazon/swage/metrics/MetricContext.java
+++ b/metrics-api/src/main/java/software/amazon/swage/metrics/MetricContext.java
@@ -13,7 +13,6 @@ import software.amazon.swage.collection.TypedMap;
  * <p/>
  * A {MetricContext} is the primary interface used to record measurements.
  */
-// TODO: provide a childContext() mechanism?
 public interface MetricContext extends AutoCloseable {
     /**
      * Returns the attributes and their values that identity the context in which measurements
@@ -71,6 +70,25 @@ public interface MetricContext extends AutoCloseable {
      */
     default void count(Metric label) {
         count(label, 1L);
+    }
+
+    /**
+     * Create a child context with the supplied attributes.
+     * The child context will inherited the attributes from this instance and
+     * use the supplied attributes as overrides.
+     *
+     * @param attributes the attribute overrides to apply.
+     * @return a new child context with combined attributes.
+     */
+    MetricContext newChildContext(TypedMap attributes);
+
+    /**
+     * Create a new child context with attributes attributes inherited from this instance.
+     *
+     * @return a new child context with attributes attributes inherited from this instance.
+     */
+    default MetricContext newChildContext(){
+       return newChildContext(TypedMap.empty());
     }
 
     /**

--- a/metrics-api/src/main/java/software/amazon/swage/metrics/NullContext.java
+++ b/metrics-api/src/main/java/software/amazon/swage/metrics/NullContext.java
@@ -2,6 +2,7 @@ package software.amazon.swage.metrics;
 
 import java.time.Instant;
 
+import software.amazon.swage.collection.ImmutableTypedMap;
 import software.amazon.swage.collection.TypedMap;
 
 /**
@@ -40,6 +41,13 @@ public class NullContext implements MetricContext {
 
     @Override
     public void count(Metric label, long delta) {
+    }
+
+    @Override
+    public MetricContext newChildContext(TypedMap attributes) {
+        ImmutableTypedMap.Builder childAttributes = ImmutableTypedMap.Builder.from(this.attributes);
+        attributes.stream().forEach(entry -> childAttributes.add(entry.getKey(), entry.getValue()));
+        return new NullContext(attributes);
     }
 
     @Override

--- a/metrics-api/src/main/java/software/amazon/swage/metrics/record/DefaultMetricContext.java
+++ b/metrics-api/src/main/java/software/amazon/swage/metrics/record/DefaultMetricContext.java
@@ -1,0 +1,46 @@
+package software.amazon.swage.metrics.record;
+
+import software.amazon.swage.collection.ImmutableTypedMap;
+import software.amazon.swage.collection.TypedMap;
+import software.amazon.swage.metrics.Metric;
+import software.amazon.swage.metrics.MetricContext;
+import software.amazon.swage.metrics.Unit;
+
+import java.time.Instant;
+
+final class DefaultMetricContext implements MetricContext {
+    private final MetricRecorder.RecorderContext context;
+    private final MetricRecorder recorder;
+
+    public DefaultMetricContext(MetricRecorder recorder, TypedMap attributes) {
+        this.recorder = recorder;
+        this.context = recorder.newRecorderContext(attributes);
+    }
+
+    @Override
+    public TypedMap attributes() {
+        return context.attributes();
+    }
+
+    @Override
+    public void record(Metric label, Number value, Unit unit, Instant time) {
+        recorder.record(label, value, unit, time, context);
+    }
+
+    @Override
+    public void count(Metric label, long delta) {
+        recorder.count(label, delta, context);
+    }
+
+    @Override
+    public void close() {
+        recorder.close(context);
+    }
+
+    @Override
+    public MetricContext newChildContext(TypedMap attributes) {
+        ImmutableTypedMap.Builder childAttributes = ImmutableTypedMap.Builder.from(context.attributes());
+        attributes.stream().forEach(entry -> childAttributes.add(entry.getKey(), entry.getValue()));
+        return new DefaultMetricContext(recorder, childAttributes.build());
+    }
+}

--- a/metrics-api/src/main/java/software/amazon/swage/metrics/record/MetricRecorder.java
+++ b/metrics-api/src/main/java/software/amazon/swage/metrics/record/MetricRecorder.java
@@ -119,28 +119,7 @@ public abstract class MetricRecorder<R extends MetricRecorder.RecorderContext> {
      * @return a context for recording metrics
      */
     public MetricContext context(TypedMap attributes) {
-        R context = newRecorderContext(attributes);
-        return new MetricContext() {
-            @Override
-            public TypedMap attributes() {
-                return context.attributes();
-            }
-
-            @Override
-            public void record(Metric label, Number value, Unit unit, Instant time) {
-                MetricRecorder.this.record(label, value, unit, time, context);
-            }
-
-            @Override
-            public void count(Metric label, long delta) {
-                MetricRecorder.this.count(label, delta, context);
-            }
-
-            @Override
-            public void close() {
-                MetricRecorder.this.close(context);
-            }
-        };
+        return new DefaultMetricContext(this, attributes);
     }
 
     /**

--- a/metrics-api/src/test/java/software/amazon/swage/metrics/record/DefaultMetricContextTest.java
+++ b/metrics-api/src/test/java/software/amazon/swage/metrics/record/DefaultMetricContextTest.java
@@ -1,0 +1,48 @@
+package software.amazon.swage.metrics.record;
+
+import org.junit.Test;
+import software.amazon.swage.collection.ImmutableTypedMap;
+import software.amazon.swage.collection.TypedMap;
+import software.amazon.swage.metrics.ContextData;
+import software.amazon.swage.metrics.MetricContext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+public class DefaultMetricContextTest {
+    @Test
+    public void childContextReturnsCombinedAttributes() {
+        TypedMap.Key<String> grandParentKey = TypedMap.key("grandParent", String.class);
+        TypedMap.Key<String> parentKey = TypedMap.key("parent", String.class);
+        TypedMap.Key<String> childKey = TypedMap.key("child", String.class);
+        String grandParentValue = "grandParent";
+        String parentValue = "parent";
+        String childValue = "child";
+
+        TypedMap attributes = ImmutableTypedMap.Builder
+                .with(grandParentKey, grandParentValue)
+                .add(ContextData.ID, "1")
+                .build();
+        TypedMap parentAttributes = ImmutableTypedMap.Builder
+                .with(parentKey, parentValue)
+                .add(ContextData.ID, "2")
+                .build();
+        TypedMap childAttributes = ImmutableTypedMap.Builder
+                .with(childKey, childValue)
+                .add(ContextData.ID, "3")
+                .build();
+
+        MetricRecorder recorder = new NullRecorder();
+        MetricContext grandParentContext = new DefaultMetricContext(recorder, attributes);
+        MetricContext parentContext = grandParentContext.newChildContext(parentAttributes);
+        MetricContext childContext = parentContext.newChildContext(childAttributes);
+
+        TypedMap actualChildAttributes = childContext.attributes();
+        assertEquals(4, actualChildAttributes.size());
+        assertEquals(grandParentValue, actualChildAttributes.get(grandParentKey));
+        assertEquals(parentValue, actualChildAttributes.get(parentKey));
+        assertEquals(childValue, actualChildAttributes.get(childKey));
+        assertEquals("3", actualChildAttributes.get(ContextData.ID));
+    }
+}


### PR DESCRIPTION
Add the ability to create a child MetricContext from an instance. The child context will inherit the attributes from the parent with the option of providing additional attributes as overrides. 
The child and parent lifecycles are independent. Calling close on one of them will not effect the other. 