### PR TITLE
Fix illegal JMX metric names

### DIFF
--- a/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/sensor/MemoryPoolSensor.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/sensor/MemoryPoolSensor.java
@@ -44,7 +44,9 @@ public class MemoryPoolSensor implements Sensor {
 
     private void reportUsage(MemoryPoolMXBean mxBean, MetricContext metricContext)
     {
-        String name = mxBean.getName();
+        // Metric names cannot contain spaces. Pool names are *all* of the form 'Alpha Beta', e.g.
+        // 'Code Cache'.
+        String name = mxBean.getName().replace(" ", "");
         Metric usedMetric = Metric.define("MemoryPoolUsed_" + name);
         Metric maxMetric = Metric.define("MemoryPoolMax_" + name);
         Metric percMetric = Metric.define("MemoryPoolUsage_" + name);


### PR DESCRIPTION
Memory pools are appended to some metrics, and they contain illegal
characters (e.g. 'Code Cache'). I have confirmed that all other JMX
sensors are fine (with the exceptions of DiskUsageSensor and
RuntimeSensor, which I am not using) are fine.

---

The memory pool names for reference:

* Eden Space
* Survivor Space
* Tenured Gen
* Code Cache
* Perm Gen (In Java 1.8, replaced with ... *Metaspace*?)