### PR TITLE
Use lossless unit conversion (bytes -> megabytes)

### DIFF
--- a/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/sensor/BufferPoolSensor.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/sensor/BufferPoolSensor.java
@@ -29,7 +29,7 @@ import java.util.List;
  */
 public class BufferPoolSensor implements Sensor {
 
-    private static final long M = 1024*1024;
+    private static final double M = 1024.0 * 1024.0;
 
     @Override
     public void sense(final MetricContext metricContext)
@@ -44,8 +44,8 @@ public class BufferPoolSensor implements Sensor {
             Metric maxMetric = Metric.define("BufferPoolMax_"+name);
 
             metricContext.record(countMetric, mxBean.getCount(), Unit.NONE);
-            metricContext.record(usedMetric, mxBean.getMemoryUsed() / M, Unit.MEGABYTE);
-            metricContext.record(maxMetric,  mxBean.getTotalCapacity() / M, Unit.MEGABYTE);
+            metricContext.record(usedMetric, (double)mxBean.getMemoryUsed() / M, Unit.MEGABYTE);
+            metricContext.record(maxMetric, (double)mxBean.getTotalCapacity() / M, Unit.MEGABYTE);
         }
 
     }

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/sensor/DiskUsageSensor.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/sensor/DiskUsageSensor.java
@@ -30,7 +30,7 @@ import java.nio.file.Paths;
  */
 public class DiskUsageSensor implements Sensor {
 
-    private static final long K = 1024;
+    private static final long G = 1024L * 1024L * 1024L;
 
     public static final TypedMap.Key<Long> DISK_SIZE = TypedMap.key("DiskSize", Long.class);
     public static final Metric DISK_USED = Metric.define("DiskUse");
@@ -43,8 +43,10 @@ public class DiskUsageSensor implements Sensor {
             FileStore fileStore = Files.getFileStore(Paths.get(System.getProperty("user.dir")));
 
             long size = fileStore.getTotalSpace();
-            long gb_size = size/(K*K*K);
-            return ImmutableTypedMap.Builder.from(existing).add(DISK_SIZE, Long.valueOf(gb_size)).build();
+            return ImmutableTypedMap.Builder
+                    .from(existing)
+                    .add(DISK_SIZE, Long.valueOf(size / G))
+                    .build();
         } catch (IOException e) {
             // log?
             return existing;
@@ -60,8 +62,8 @@ public class DiskUsageSensor implements Sensor {
 
             long total = fileStore.getTotalSpace();
             long free = fileStore.getUsableSpace();
-            double percent_free = 100.0 * ((double)(total-free)/(double)total);
-            metricContext.record(DISK_USED, percent_free, Unit.PERCENT);
+            double percentFree = 100.0 * ((double)(total - free) / (double)total);
+            metricContext.record(DISK_USED, percentFree, Unit.PERCENT);
         } catch (IOException e) {
             throw new SenseException("Problem reading disk space", e);
         }

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/sensor/MemoryPoolSensor.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/sensor/MemoryPoolSensor.java
@@ -29,7 +29,7 @@ import java.util.List;
  */
 public class MemoryPoolSensor implements Sensor {
 
-    private static final long M = 1024 * 1024;
+    private static final double M = 1024.0 * 1024.0;
 
     @Override
     public void sense(final MetricContext metricContext)
@@ -53,14 +53,14 @@ public class MemoryPoolSensor implements Sensor {
         long used = usage.getUsed();
         long max = usage.getMax();
 
-        metricContext.record(usedMetric, used / M, Unit.MEGABYTE);
+        metricContext.record(usedMetric, (double)used / M, Unit.MEGABYTE);
 
         // max can be undefined (-1) https://docs.oracle.com/javase/8/docs/api/java/lang/management/MemoryUsage.html
         if (max >= 0) {
-            metricContext.record(maxMetric, max / M, Unit.MEGABYTE);
+            metricContext.record(maxMetric, (double)max / M, Unit.MEGABYTE);
 
-            double used_percent = 100.0 * ((double)used/(double)max);
-            metricContext.record(percMetric, used_percent, Unit.PERCENT);
+            double usedPercent = 100.0 * ((double)used / (double)max);
+            metricContext.record(percMetric, usedPercent, Unit.PERCENT);
         }
 
     }

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/sensor/MemorySensor.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/sensor/MemorySensor.java
@@ -29,7 +29,7 @@ import java.lang.management.MemoryUsage;
  */
 public class MemorySensor implements Sensor {
 
-    private static final long M = 1024*1024;
+    private static final double M = 1024.0 * 1024.0;
 
     public static final Metric HEAP = Metric.define("HeapMemory");
     public static final Metric NON_HEAP = Metric.define("NonHeapMemory");
@@ -51,14 +51,14 @@ public class MemorySensor implements Sensor {
         MemoryUsage usage = memoryMxBean.getHeapMemoryUsage();
 
         long used = usage.getUsed();
-        metricContext.record(HEAP, used / M, Unit.MEGABYTE);
+        metricContext.record(HEAP, (double)used / M, Unit.MEGABYTE);
 
         long max = usage.getMax();
         if (max >= 0) {
-            metricContext.record(HEAP_MAX, max / M, Unit.MEGABYTE);
+            metricContext.record(HEAP_MAX, (double)max / M, Unit.MEGABYTE);
 
-            double used_percent = 100.0 * ((double)used/(double)max);
-            metricContext.record(HEAP_USED, used_percent, Unit.PERCENT);
+            double usedPercent = 100.0 * ((double)used / (double)max);
+            metricContext.record(HEAP_USED, usedPercent, Unit.PERCENT);
         }
     }
 
@@ -66,14 +66,14 @@ public class MemorySensor implements Sensor {
         MemoryUsage usage = memoryMxBean.getNonHeapMemoryUsage();
 
         long used = usage.getUsed();
-        metricContext.record(NON_HEAP, used / M, Unit.MEGABYTE);
+        metricContext.record(NON_HEAP, (double)used / M, Unit.MEGABYTE);
 
         long max = usage.getMax();
         if (max >= 0) {
-            metricContext.record(NON_HEAP_MAX, max / M, Unit.MEGABYTE);
+            metricContext.record(NON_HEAP_MAX, (double)max / M, Unit.MEGABYTE);
 
-            double used_percent = 100.0 * ((double)used/(double)max);
-            metricContext.record(NON_HEAP_USED, used_percent, Unit.PERCENT);
+            double usedPercent = 100.0 * ((double)used / (double)max);
+            metricContext.record(NON_HEAP_USED, usedPercent, Unit.PERCENT);
         }
     }
 

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/sensor/OperatingSystemSensor.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/sensor/OperatingSystemSensor.java
@@ -88,8 +88,8 @@ public class OperatingSystemSensor implements Sensor {
             metricContext.record(FILE_DESCRIPTORS_OPEN, open, Unit.NONE);
 
             if (open >= 0) {
-                double use_percent = 100.0 * ((double) open / (double) max);
-                metricContext.record(FILE_DESCRIPTORS_USED, use_percent, Unit.PERCENT);
+                double usePercent = 100.0 * ((double)open / (double)max);
+                metricContext.record(FILE_DESCRIPTORS_USED, usePercent, Unit.PERCENT);
             }
         }
         catch (MBeanException|AttributeNotFoundException|InstanceNotFoundException|ReflectionException|IOException e)


### PR DESCRIPTION
Previously, [long] division was used. This was then cast to a [double]
before publishing, dropping the remainder.

---

I *also* distrust implicit type conversion :). That's what led to the StageFright exploit in Android. I kept that all in place.

As a matter of policy, I always do division last, so I refactored the percentage calculation. Doing division before other arithmetic amplifies the loss in precision. It isn't really noticeable, and I can undo those changes (but the snake_case to camelCase changes you may want to keep).