### PR TITLE
Explicitly aggregate counts within a context in MetricRecorder

### DIFF
--- a/metrics-api/src/main/java/software/amazon/swage/metrics/MetricContext.java
+++ b/metrics-api/src/main/java/software/amazon/swage/metrics/MetricContext.java
@@ -53,9 +53,10 @@ public interface MetricContext extends AutoCloseable {
      * is often used to record occurrences of an event, such as the number of times
      * a method is called, an error occurred, or the amount of data sent.
      * <p/>
-     * Changes to the count are not timestamped as only the total value of all
-     * counts for a metric have any meaning. If the individual change needs to
-     * be tracked, it should be recorded as a gauged event.
+     * Changes to the count are timestamped with the time of context closure,
+     * since only the total value of all counts for a metric at the end of a context
+     * have any meaning. If the individual change needs to be tracked, it should be
+     * recorded as a gauged event.
      *
      * @param label the metric being recorded
      * @param delta the change in the value

--- a/metrics-api/src/main/java/software/amazon/swage/metrics/record/MetricRecorder.java
+++ b/metrics-api/src/main/java/software/amazon/swage/metrics/record/MetricRecorder.java
@@ -15,6 +15,8 @@
 package software.amazon.swage.metrics.record;
 
 import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import software.amazon.swage.collection.TypedMap;
 import software.amazon.swage.metrics.Metric;
@@ -121,6 +123,8 @@ public abstract class MetricRecorder<R extends MetricRecorder.RecorderContext> {
     public MetricContext context(TypedMap attributes) {
         R context = newRecorderContext(attributes);
         return new MetricContext() {
+            private final Map<Metric,Long> counts = new ConcurrentHashMap<>();
+
             @Override
             public TypedMap attributes() {
                 return context.attributes();
@@ -133,11 +137,12 @@ public abstract class MetricRecorder<R extends MetricRecorder.RecorderContext> {
 
             @Override
             public void count(Metric label, long delta) {
-                MetricRecorder.this.count(label, delta, context);
+                counts.compute(label, (x, previous) -> (previous == null) ? delta : previous + delta);
             }
 
             @Override
             public void close() {
+                counts.forEach((key, value) -> MetricRecorder.this.count(key, value, context));
                 MetricRecorder.this.close(context);
             }
         };
@@ -172,7 +177,7 @@ public abstract class MetricRecorder<R extends MetricRecorder.RecorderContext> {
             R context);
 
     /**
-     * Count the increase or decrease of a metric in the given context.
+     * Record the value of a count metric at the closure of a context.
      *
      * These are explicitly aggregated values, where only the total number of
      * occurrences in a context matter.
@@ -180,21 +185,20 @@ public abstract class MetricRecorder<R extends MetricRecorder.RecorderContext> {
      * track of the number of errors encountered, or the amount of attributes sent
      * while in the given context.
      *
+     * Changes to the count are timestamped with the time of context closure,
+     * as only the total value of all counts for a metric have any meaning.
      * If you need to distinguish between occurrences of an event, or care that
      * an event did not occur (for ratios of success for example) then you want
      * to record those individually and not use a count.
-     * Changes to the count are not timestamped as only the total value of all
-     * counts for a metric have any meaning - if the individual change needs to
-     * be tracked, you probably want to record the change as a gauged event.
      *
      * This method will fail silently, as application code is not expected
      * to depend on success or failure.
      *
      * @param label the metric to capture
-     * @param delta the increase (or decrease) in the value
+     * @param value the total value of the count at the end of the context
      * @param context the context the value belongs in.
      */
-    protected abstract void count(Metric label, long delta, R context);
+    protected abstract void count(Metric label, long value, R context);
 
 
     /**

--- a/metrics-api/src/test/java/software/amazon/swage/metrics/record/MultiRecorderTest.java
+++ b/metrics-api/src/test/java/software/amazon/swage/metrics/record/MultiRecorderTest.java
@@ -7,8 +7,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -43,9 +46,18 @@ public class MultiRecorderTest {
     }
 
     @Test
-    public void countIsSentToAllDelegates() {
+    public void countIsNotSentToDelegatesBeforeClose() {
         MetricContext context = recorder.context(attributes);
         context.count(METRIC, 42L);
+        verify(delegate1, times(0)).count(any(Metric.class), anyLong(), any(MetricRecorder.RecorderContext.class));
+        verify(delegate2, times(0)).count(any(Metric.class), anyLong(), any(MetricRecorder.RecorderContext.class));
+    }
+
+    @Test
+    public void countIsSentToAllDelegatesOnClose() {
+        MetricContext context = recorder.context(attributes);
+        context.count(METRIC, 42L);
+        context.close();
         verify(delegate1).count(eq(METRIC), eq(42L), argThat(t -> attributes == t.attributes()));
         verify(delegate2).count(eq(METRIC), eq(42L), argThat(t -> attributes == t.attributes()));
     }

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorderTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorderTest.java
@@ -197,10 +197,10 @@ public class CloudWatchRecorderTest {
                                StandardUnit.Percent));
         expected.add(makeDatum(id,
                                M_FAIL.toString(),
-                               Arrays.stream(failCnts).sum(),
-                               Arrays.stream(failCnts).min().getAsInt(),
-                               Arrays.stream(failCnts).max().getAsInt(),
-                               failCnts.length,
+                               46,
+                               46,
+                               46,
+                               1,
                                StandardUnit.Count));
 
 


### PR DESCRIPTION
While the javadocs previously indicated that Counts were to be explicitly aggregated values (where only the total at the end of a context had any meaning), it was left up to MetricRecorder implementations to get this right.  This change enforces the contract from the javadoc by handling the aggregation of counts in the abstract MetricRecorder class.