### PR TITLE
ImmutableTypeMap.Builder now creates a copy of the map

### DIFF
--- a/type-safe/src/main/java/software/amazon/swage/collection/ImmutableTypedMap.java
+++ b/type-safe/src/main/java/software/amazon/swage/collection/ImmutableTypedMap.java
@@ -150,7 +150,7 @@ public final class ImmutableTypedMap implements TypedMap {
         }
 
         public ImmutableTypedMap build() {
-            return new ImmutableTypedMap(dataMap);
+            return new ImmutableTypedMap(new IdentityHashMap<>(dataMap));
         }
     }
 

--- a/type-safe/src/test/java/software/amazon/swage/collection/ImmutableTypedMapTest.java
+++ b/type-safe/src/test/java/software/amazon/swage/collection/ImmutableTypedMapTest.java
@@ -354,4 +354,23 @@ public class ImmutableTypedMapTest {
         assertFalse("forEachTyped hit an unexpected entry", seen[4]);
     }
 
+    @Test
+    public void testMultipleBuildsDontMutateInstances() {
+        final TypedMap.Key<String> strKey = TypedMap.key("TestId1", String.class);
+        final String foo = "FOO";
+        final String bar = "BAR";
+
+        ImmutableTypedMap.Builder builder = ImmutableTypedMap.Builder.with(strKey, foo);
+        TypedMap firstInstance = builder.build();
+        String originalValue = firstInstance.get(strKey);
+
+        assertEquals(foo, originalValue);
+
+        // Override existing key using the same builder
+        TypedMap secondInstance = builder.add(strKey, bar).build();
+
+        // first instance should not be mutated
+        assertEquals(originalValue, firstInstance.get(strKey));
+        assertEquals(bar, secondInstance.get(strKey));
+    }
 }


### PR DESCRIPTION
Fix a bug that allowed the TypedMaps to be mutated via their builders by
creating a copy of the map before passing it to the TypedMap.

*Issue #, if available:* N/A

*Description of changes:* 
When calling ImmutableTypeMap.Builder build(), instead of passing to the instance a reference to the map backing the builder a new map is created with a copy of the values to prevent any additions to the backing map from affecting the map stored inside the map instance.