### PR TITLE
Add a JMX sensor for heap size after GC

### DIFF
--- a/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/sensor/HeapMemoryAfterGCSensor.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/jmx/sensor/HeapMemoryAfterGCSensor.java
@@ -1,0 +1,74 @@
+package software.amazon.swage.metrics.jmx.sensor;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryUsage;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+
+import software.amazon.swage.metrics.Metric;
+import software.amazon.swage.metrics.MetricContext;
+import software.amazon.swage.metrics.Unit;
+
+public class HeapMemoryAfterGCSensor implements Sensor {
+
+    private static final List<String> LONG_LIVED_MEMORY_POOL_NAMES =
+            Arrays.asList("Old", "Tenured", "Survivor");
+    // Visible for testing
+    static final Metric HEAP_AFTER_GC_USE = Metric.define("HeapMemoryAfterGCUse");
+
+    private final Supplier<List<MemoryPoolMXBean>> memoryPoolMXBeanSupplier;
+
+    public HeapMemoryAfterGCSensor() {
+        this(() -> ManagementFactory.getMemoryPoolMXBeans());
+    }
+
+    HeapMemoryAfterGCSensor(final Supplier<List<MemoryPoolMXBean>> memoryPoolMXBeanSupplier) {
+        this.memoryPoolMXBeanSupplier = memoryPoolMXBeanSupplier;
+    }
+
+    @Override
+    public void sense(final MetricContext metricContext) {
+        final List<MemoryPoolMXBean> memoryPoolMXBeans = memoryPoolMXBeanSupplier.get();
+        if (memoryPoolMXBeans == null) {
+            throw new IllegalStateException("No memory pool MX beans available");
+        }
+
+        // Get the used and available old gen and survivor space after the last GC to calculate the heap usage.
+        long usedKb = 0, totalKb = 0;
+        for (final MemoryPoolMXBean memoryPool : memoryPoolMXBeanSupplier.get()) {
+            if (isLongLivedMemoryPool(memoryPool)) {
+                final MemoryUsage memoryPoolData = memoryPool.getCollectionUsage();
+
+                // .getCollectionUsage() is not supported for all memory pools:
+                // https://docs.oracle.com/javase/7/docs/api/java/lang/management/MemoryPoolMXBean.html#getCollectionUsage()
+                if (memoryPoolData != null) {
+                    final long used = memoryPoolData.getUsed();
+                    usedKb += used / 1024;
+
+                    final long max = memoryPoolData.getMax();
+                    // Max can be undefined (-1) http://docs.oracle.com/javase/7/docs/api/java/lang/management/MemoryUsage.html
+                    totalKb += max == -1 ? 0 : max / 1024;
+                }
+            }
+        }
+        recordHeapAfterGcUsePercentageMetric(metricContext, usedKb, totalKb);
+    }
+
+    private boolean isLongLivedMemoryPool(final MemoryPoolMXBean memoryPoolMXBean) {
+        final String memoryPoolName = memoryPoolMXBean.getName();
+        if (memoryPoolName != null) {
+            return LONG_LIVED_MEMORY_POOL_NAMES.stream()
+                .anyMatch(nameComponent -> memoryPoolName.contains(nameComponent));
+        }
+        return false;
+    }
+
+    private void recordHeapAfterGcUsePercentageMetric(final MetricContext metricContext, final long usedKb, final long totalKb) {
+        if (totalKb > 0) {
+            final double percent = 100.0 * (double) usedKb / (double) totalKb;
+            metricContext.record(HEAP_AFTER_GC_USE, percent, Unit.PERCENT);
+        }
+    }
+}

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/jmx/sensor/HeapMemoryAfterGCSensorTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/jmx/sensor/HeapMemoryAfterGCSensorTest.java
@@ -1,0 +1,179 @@
+package software.amazon.swage.metrics.jmx.sensor;
+
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryUsage;
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.swage.metrics.MetricContext;
+import software.amazon.swage.metrics.Unit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static software.amazon.swage.metrics.jmx.sensor.HeapMemoryAfterGCSensor.HEAP_AFTER_GC_USE;
+
+public class HeapMemoryAfterGCSensorTest {
+    private static final String OLD_MEM_POOL = "OldPool";
+    private static final String EDEN_MEM_POOL = "EdenPool";
+    private static final String TENURED_MEM_POOL = "TenuredPool";
+
+    private MetricContext metricContext;
+
+    @Before
+    public void initialize() {
+        metricContext = mock(MetricContext.class);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void sense_withNullMemoryPoolList_throwsIllegalStateException() {
+        new HeapMemoryAfterGCSensor(() -> null).sense(metricContext);
+    }
+
+    @Test
+    public void sense_withNoMemoryPools_doesNotRecordMetric() {
+        final HeapMemoryAfterGCSensor sensor =
+                new HeapMemoryAfterGCSensor(() -> Arrays.asList());
+        sensor.sense(metricContext);
+
+        verify(metricContext, never()).record(any(), any(), any());
+    }
+
+    @Test
+    public void sense_withNullLongLivedMemoryPoolData_doesNotRecordMetric() {
+        final MemoryPoolMXBean oldMemPoolWithNullData = mock(MemoryPoolMXBean.class);
+        when(oldMemPoolWithNullData.getName()).thenReturn(OLD_MEM_POOL);
+        when(oldMemPoolWithNullData.getCollectionUsage()).thenReturn(null);
+
+        final HeapMemoryAfterGCSensor sensor =
+                new HeapMemoryAfterGCSensor(() -> Arrays.asList(oldMemPoolWithNullData));
+        sensor.sense(metricContext);
+
+        verify(metricContext, never()).record(any(), any(), any());
+    }
+
+    @Test
+    public void sense_withMemoryPoolWithoutName_doesNotRecordMetric() {
+        final MemoryPoolMXBean memPoolWithNullName = mock(MemoryPoolMXBean.class);
+        when(memPoolWithNullName.getName()).thenReturn(null);
+
+        final HeapMemoryAfterGCSensor sensor =
+                new HeapMemoryAfterGCSensor(() -> Arrays.asList(memPoolWithNullName));
+        sensor.sense(metricContext);
+
+        verify(metricContext, never()).record(any(), any(), any());
+    }
+
+    @Test
+    public void sense_withNoLongLivedMemory_doesNotRecordMetric() {
+        final long usedMem = 1024L;
+        final long totalMem = 10240L;
+        final MemoryPoolMXBean edenMemPool = setupMemoryPoolData(EDEN_MEM_POOL, usedMem, totalMem);
+
+        final HeapMemoryAfterGCSensor sensor =
+                new HeapMemoryAfterGCSensor(() -> Arrays.asList(edenMemPool));
+        sensor.sense(metricContext);
+
+        verify(metricContext, never()).record(any(), any(), any());
+    }
+
+    @Test
+    public void sense_withSingleLongLivedMemoryPool_recordsSingleMetric() {
+        final long usedMem = 1024L;
+        final long totalMem = 10240L;
+        final double expectedUseMetric = 100.0 * usedMem / totalMem;
+
+        final MemoryPoolMXBean oldMemPool = setupMemoryPoolData(OLD_MEM_POOL, usedMem, totalMem);
+
+        final HeapMemoryAfterGCSensor sensor =
+                new HeapMemoryAfterGCSensor(() -> Arrays.asList(oldMemPool));
+        sensor.sense(metricContext);
+
+        verify(metricContext, times(1)).record(HEAP_AFTER_GC_USE, expectedUseMetric, Unit.PERCENT);
+    }
+
+    @Test
+    public void sense_withSingleLongLivedMemoryPoolButUndefinedMax_doesNotRecordMetric() {
+        final long usedMem = 1024L;
+        final long totalMem = -1L;
+
+        final MemoryPoolMXBean oldMemPool = setupMemoryPoolData(OLD_MEM_POOL, usedMem, totalMem);
+
+        final HeapMemoryAfterGCSensor sensor =
+                new HeapMemoryAfterGCSensor(() -> Arrays.asList(oldMemPool));
+        sensor.sense(metricContext);
+
+        verify(metricContext, never()).record(any(), any(), any());
+    }
+
+    @Test
+    public void sense_withShortAndLongLivedMemoryPool_recordsSingleMetric() {
+        final long oldUsedMem = 1024L;
+        final long oldTotalMem = 10240L;
+        final long edenUsedMem = 2048L;
+        final long edenTotalMem = 20480L;
+        final double expectedUseMetric = 100.0 * oldUsedMem / oldTotalMem;
+
+        final MemoryPoolMXBean oldMemPool = setupMemoryPoolData(OLD_MEM_POOL, oldUsedMem, oldTotalMem);
+        final MemoryPoolMXBean edenMemPool = setupMemoryPoolData(EDEN_MEM_POOL, edenUsedMem, edenTotalMem);
+
+        final HeapMemoryAfterGCSensor sensor =
+                new HeapMemoryAfterGCSensor(() -> Arrays.asList(oldMemPool, edenMemPool));
+        sensor.sense(metricContext);
+
+        verify(metricContext, times(1)).record(HEAP_AFTER_GC_USE, expectedUseMetric, Unit.PERCENT);
+    }
+
+    @Test
+    public void sense_withTwoLongLivedMemoryPools_recordsAggregateMetric() {
+        final long oldUsedMem = 1024L;
+        final long oldTotalMem = 10240L;
+        final long tenuredUsedMem = 2048L;
+        final long tenuredTotalMem = 20480L;
+        final double expectedUseMetric =
+                100.0 * (oldUsedMem + tenuredUsedMem) / (oldTotalMem + tenuredTotalMem);
+
+        final MemoryPoolMXBean oldMemPool = setupMemoryPoolData(OLD_MEM_POOL, oldUsedMem, oldTotalMem);
+        final MemoryPoolMXBean tenuredMemPool = setupMemoryPoolData(TENURED_MEM_POOL, tenuredUsedMem, tenuredTotalMem);
+
+        final HeapMemoryAfterGCSensor sensor =
+                new HeapMemoryAfterGCSensor(() -> Arrays.asList(oldMemPool, tenuredMemPool));
+        sensor.sense(metricContext);
+
+        verify(metricContext, times(1)).record(HEAP_AFTER_GC_USE, expectedUseMetric, Unit.PERCENT);
+    }
+
+    @Test
+    public void sense_withTwoLongLivedMemoryPoolsAndOneUndefinedMax_recordsAggregateMetric() {
+        final long oldUsedMem = 1024L;
+        final long oldTotalMem = -1L;
+        final long tenuredUsedMem = 2048L;
+        final long tenuredTotalMem = 20480L;
+        final double expectedUseMetric =
+                100.0 * (oldUsedMem + tenuredUsedMem) / tenuredTotalMem;
+
+        final MemoryPoolMXBean oldMemPool = setupMemoryPoolData(OLD_MEM_POOL, oldUsedMem, oldTotalMem);
+        final MemoryPoolMXBean tenuredMemPool = setupMemoryPoolData(TENURED_MEM_POOL, tenuredUsedMem, tenuredTotalMem);
+
+        final HeapMemoryAfterGCSensor sensor =
+                new HeapMemoryAfterGCSensor(() -> Arrays.asList(oldMemPool, tenuredMemPool));
+        sensor.sense(metricContext);
+
+        verify(metricContext, times(1)).record(HEAP_AFTER_GC_USE, expectedUseMetric, Unit.PERCENT);
+    }
+
+    private MemoryPoolMXBean setupMemoryPoolData(final String memoryPoolName, final long usedBytes, final long maxBytes) {
+        final MemoryPoolMXBean memoryPoolMXBean = mock(MemoryPoolMXBean.class);
+        final MemoryUsage memoryUsage = mock(MemoryUsage.class);
+        when(memoryUsage.getUsed()).thenReturn(usedBytes);
+        when(memoryUsage.getMax()).thenReturn(maxBytes);
+        when(memoryPoolMXBean.getName()).thenReturn(memoryPoolName);
+        when(memoryPoolMXBean.getCollectionUsage()).thenReturn(memoryUsage);
+
+        return memoryPoolMXBean;
+    }
+}


### PR DESCRIPTION
**Description of changes:**
Add a new JMX sensor to calculate heap size after garbage collection, which the existing MemorySensor does not calculate. This functionality could be added to the existing MemorySensor, but I kept it separate so that consumers could choose which metrics they want.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing of changes:**
Ran `mvn clean install` to verify tests passed. I also used this sensor in a local project to verify the metric.
```
[masonme@f45c89b36d13] $ mvn clean install
...
[INFO] Running software.amazon.swage.metrics.jmx.sensor.HeapMemoryAfterGCSensorTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.182 s - in software.amazon.swage.metrics.jmx.sensor.HeapMemoryAfterGCSensorTest
...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] parent 1.0-SNAPSHOT ................................ SUCCESS [  0.529 s]
[INFO] disseminating-executors ............................ SUCCESS [  4.975 s]
[INFO] Swage Type Safe .................................... SUCCESS [  1.304 s]
[INFO] Thread Context Support ............................. SUCCESS [  1.154 s]
[INFO] Swage Metrics API .................................. SUCCESS [  1.964 s]
[INFO] Swage Metrics Core Implementation 1.0-SNAPSHOT ..... SUCCESS [  6.737 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 16.847 s
[INFO] Finished at: 2020-12-10T12:01:18-08:00
[INFO] ------------------------------------------------------------------------
```