### PR TITLE
Upgrade to AWS SDK 2, JUnit 5

### DIFF
--- a/disseminating-executors/pom.xml
+++ b/disseminating-executors/pom.xml
@@ -12,7 +12,7 @@
       <groupId>software.amazon.swage</groupId>
       <version>1.0-SNAPSHOT</version>
     </parent>
-    
+
     <artifactId>disseminating-executors</artifactId>
 
     <dependencies>
@@ -25,19 +25,19 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.1.0</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>
-            <version>1.0-rc2</version>
+            <version>1.0.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/disseminating-executors/src/main/java/software/amazon/swage/concurrent/CapturedState.java
+++ b/disseminating-executors/src/main/java/software/amazon/swage/concurrent/CapturedState.java
@@ -31,7 +31,7 @@ public interface CapturedState {
      * will be executed immediately, the execution of the wrapped thread
      * will be skipped, and the exception will then be the execution result.
      */
-    public void beforeThreadExecution();
+    void beforeThreadExecution();
 
     /**
      * In the context of a wrapped executing thread,
@@ -46,5 +46,5 @@ public interface CapturedState {
      * <code>beforeThreadExecution()</code> threw an exception, the behavior
      * is undefined.
      */
-    public void afterThreadExecution();
+    void afterThreadExecution();
 }

--- a/disseminating-executors/src/main/java/software/amazon/swage/concurrent/StateCaptor.java
+++ b/disseminating-executors/src/main/java/software/amazon/swage/concurrent/StateCaptor.java
@@ -40,5 +40,5 @@ public interface StateCaptor<T extends CapturedState> {
      * @return a CapturedState which will be called in the context of an
      * executing thread immediately before and after its execution.
      */
-    public T get();
+    T get();
 }

--- a/disseminating-executors/src/main/java/software/amazon/swage/concurrent/StateCapture.java
+++ b/disseminating-executors/src/main/java/software/amazon/swage/concurrent/StateCapture.java
@@ -102,7 +102,7 @@ public final class StateCapture {
      * If the passed in executor service is already decorated, or there are no registered
      * state captors, the delegate executor service is returned unmodified.
      *
-     * @param executor executor service to delegate execution to
+     * @param executorService executor service to delegate execution to
      * @return an executor service that wraps Runnables / Callables
      */
     public static ExecutorService capturingDecorator(final ExecutorService executorService) {

--- a/disseminating-executors/src/test/java/software/amazon/swage/concurrent/StateCaptureTest.java
+++ b/disseminating-executors/src/test/java/software/amazon/swage/concurrent/StateCaptureTest.java
@@ -14,8 +14,8 @@
  */
 package software.amazon.swage.concurrent;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -35,16 +35,16 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
 /**
  * Verifies that captures work as expected
  */
-public class StateCaptureTest {
+class StateCaptureTest {
 
     @Test
-    public void testExecutorCaptures() throws InterruptedException {
+    void testExecutorCaptures() throws InterruptedException {
         // Setup
         ExecutorService e = Executors.newCachedThreadPool();
         Executor f = StateCapture.capturingDecorator(e);
@@ -60,7 +60,7 @@ public class StateCaptureTest {
     }
 
     @Test
-    public void testScheduledExecutorServiceCaptures() throws InterruptedException {
+    void testScheduledExecutorServiceCaptures() throws InterruptedException {
         // Setup
         ScheduledExecutorService e = Executors.newScheduledThreadPool(10);
         ScheduledExecutorService f = StateCapture.capturingDecorator(e);
@@ -76,7 +76,7 @@ public class StateCaptureTest {
     }
 
     @Test
-    public void testCompletionServiceRunnableCaptures() throws InterruptedException, Exception {
+    void testCompletionServiceRunnableCaptures() throws Exception {
         // Setup
         ExecutorService executor = Executors.newCachedThreadPool();
         CompletionService<Object> delegate = new ExecutorCompletionService<>(executor);
@@ -95,7 +95,7 @@ public class StateCaptureTest {
     }
 
     @Test
-    public void testCompletionServiceCallableCaptures() throws InterruptedException, Exception {
+    void testCompletionServiceCallableCaptures() throws Exception {
         // Setup
         ExecutorService executor = Executors.newCachedThreadPool();
         CompletionService<Object> delegate = new ExecutorCompletionService<>(executor);
@@ -114,7 +114,7 @@ public class StateCaptureTest {
     }
 
     @Test
-    public void testExecutorServiceInvokeAllCaptures() throws Exception {
+    void testExecutorServiceInvokeAllCaptures() throws Exception {
         testExecutorServiceCallables((f, mockCallable) -> {
             List<Future<Object>> results;
             try {
@@ -127,7 +127,7 @@ public class StateCaptureTest {
     }
 
     @Test
-    public void testExecutorServiceInvokeAllTimeoutCaptures() throws Exception {
+    void testExecutorServiceInvokeAllTimeoutCaptures() throws Exception {
         testExecutorServiceCallables((f, mockCallable) -> {
             final List<Future<Object>> results;
             try {
@@ -140,7 +140,7 @@ public class StateCaptureTest {
     }
 
     @Test
-    public void testExecutorServiceInvokeAnyCaptures() throws Exception {
+    void testExecutorServiceInvokeAnyCaptures() throws Exception {
         testExecutorServiceCallables((f, mockCallable) -> {
             try {
                 return CompletableFuture.completedFuture(
@@ -152,7 +152,7 @@ public class StateCaptureTest {
     }
 
     @Test
-    public void testExecutorServiceInvokeAnyTimeoutCaptures() throws Exception {
+    void testExecutorServiceInvokeAnyTimeoutCaptures() throws Exception {
         testExecutorServiceCallables((f, mockCallable) -> {
             try {
                 return CompletableFuture.completedFuture(
@@ -164,7 +164,7 @@ public class StateCaptureTest {
     }
 
     @Test
-    public void testExecutorServiceSubmitCallableCaptures() throws Exception {
+    void testExecutorServiceSubmitCallableCaptures() throws Exception {
         testExecutorServiceCallables((f, mockCallable) -> {
             try {
                 return f.submit(mockCallable);
@@ -176,7 +176,7 @@ public class StateCaptureTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testExecutorServiceSubmitRunnableCaptures() throws Exception {
+    void testExecutorServiceSubmitRunnableCaptures() throws Exception {
         testExecutorServiceRunnables((f, mockCallable) -> {
             try {
                 return (Future<Object>)f.submit(mockCallable);
@@ -187,7 +187,7 @@ public class StateCaptureTest {
     }
 
     @Test
-    public void testExecutorServiceSubmitRunnableResultCaptures() throws Exception {
+    void testExecutorServiceSubmitRunnableResultCaptures() throws Exception {
         testExecutorServiceRunnables((f, mockCallable) -> {
             try {
                 Object result = new Object();

--- a/metrics-api/pom.xml
+++ b/metrics-api/pom.xml
@@ -25,8 +25,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/metrics-api/src/main/java/software/amazon/swage/metrics/record/MetricRecorder.java
+++ b/metrics-api/src/main/java/software/amazon/swage/metrics/record/MetricRecorder.java
@@ -233,7 +233,7 @@ public abstract class MetricRecorder<R extends MetricRecorder.RecorderContext> {
     protected void close(R context) {
     }
 
-    private final class DefaultMetricContext implements MetricContext {
+    private static final class DefaultMetricContext implements MetricContext {
         private final MetricRecorder recorder;
         private final RecorderContext context;
         private final MetricContext parent;

--- a/metrics-api/src/test/java/software/amazon/swage/metrics/MetricTest.java
+++ b/metrics-api/src/test/java/software/amazon/swage/metrics/MetricTest.java
@@ -14,17 +14,17 @@
  */
 package software.amazon.swage.metrics;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class MetricTest {
+class MetricTest {
 
     /*
      * Test validation works as expected with new metrics.
      */
     @Test
-    public void validation() throws Exception {
+    void validation() throws Exception {
         final String[] goods = {
                 "snake_case_metric",
                 "camelCaseMetric",

--- a/metrics-api/src/test/java/software/amazon/swage/metrics/NullContextTest.java
+++ b/metrics-api/src/test/java/software/amazon/swage/metrics/NullContextTest.java
@@ -1,21 +1,21 @@
 package software.amazon.swage.metrics;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
 import software.amazon.swage.collection.ImmutableTypedMap;
 import software.amazon.swage.collection.TypedMap;
 
-public class NullContextTest {
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NullContextTest {
 
     @Test
-    public void defaultContextHasNoAttributes() {
+    void defaultContextHasNoAttributes() {
         assertTrue(NullContext.empty().attributes().isEmpty());
     }
 
     @Test
-    public void nullContextCanHaveAttributes() {
+    void nullContextCanHaveAttributes() {
         TypedMap.Key<String> ID = TypedMap.key("ID", String.class);
         TypedMap attributes = ImmutableTypedMap.Builder.with(ID, "id").build();
         NullContext context = new NullContext(attributes);

--- a/metrics-api/src/test/java/software/amazon/swage/metrics/UnitTest.java
+++ b/metrics-api/src/test/java/software/amazon/swage/metrics/UnitTest.java
@@ -14,17 +14,17 @@
  */
 package software.amazon.swage.metrics;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for Units
  */
-public class UnitTest {
+class UnitTest {
 
     @Test
-    public void forSymbol() throws Exception {
+    void forSymbol() throws Exception {
         assertEquals(Unit.NONE, Unit.forSymbol(""));
         assertEquals(Unit.SECOND, Unit.forSymbol("s"));
         assertEquals(Unit.MILLISECOND, Unit.forSymbol("ms"));

--- a/metrics-api/src/test/java/software/amazon/swage/metrics/record/MetricRecorderTest.java
+++ b/metrics-api/src/test/java/software/amazon/swage/metrics/record/MetricRecorderTest.java
@@ -17,9 +17,7 @@ package software.amazon.swage.metrics.record;
 import java.time.Instant;
 import java.util.UUID;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
@@ -27,26 +25,26 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
-import software.amazon.swage.collection.ImmutableTypedMap;
 import software.amazon.swage.collection.TypedMap;
 import software.amazon.swage.metrics.ContextData;
 import software.amazon.swage.metrics.Metric;
 import software.amazon.swage.metrics.MetricContext;
 import software.amazon.swage.metrics.Unit;
 
-public class MetricRecorderTest {
+class MetricRecorderTest {
     private static final Metric METRIC = Metric.define("Metric");
 
     @Test
-    public void recorderContextReturnsSuppliedAttributes() {
+    void recorderContextReturnsSuppliedAttributes() {
         TypedMap attributes = TypedMap.empty();
         MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(attributes);
         assertSame(attributes, context.attributes());
     }
 
     @Test
-    public void recorderDelegatesToImplementation() throws Exception {
+    void recorderDelegatesToImplementation() {
         TypedMap attributes = TypedMap.empty();
         MetricRecorder.RecorderContext recorderContext = new MetricRecorder.RecorderContext(attributes);
 
@@ -66,7 +64,7 @@ public class MetricRecorderTest {
     }
 
     @Test
-    public void recorderPassesParentHierarchyToImplementation() throws Exception {
+    void recorderPassesParentHierarchyToImplementation() {
         TypedMap parentAttributes = ContextData.withId(UUID.randomUUID().toString()).build();
         TypedMap childAttributes = ContextData.withId(UUID.randomUUID().toString()).build();
         MetricRecorder.RecorderContext parentContext = new MetricRecorder.RecorderContext(parentAttributes);
@@ -89,7 +87,7 @@ public class MetricRecorderTest {
         verify(recorder).close(argThat(equals(expected)));
     }
 
-    public ArgumentMatcher<MetricRecorder.RecorderContext> equals(MetricRecorder.RecorderContext other) {
+    ArgumentMatcher<MetricRecorder.RecorderContext> equals(MetricRecorder.RecorderContext other) {
         return new ArgumentMatcher<MetricRecorder.RecorderContext>() {
             @Override
             public boolean matches(MetricRecorder.RecorderContext context) {

--- a/metrics-api/src/test/java/software/amazon/swage/metrics/record/MultiRecorderTest.java
+++ b/metrics-api/src/test/java/software/amazon/swage/metrics/record/MultiRecorderTest.java
@@ -3,22 +3,21 @@ package software.amazon.swage.metrics.record;
 import java.time.Instant;
 import java.util.Arrays;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
 import software.amazon.swage.collection.TypedMap;
 import software.amazon.swage.metrics.Metric;
 import software.amazon.swage.metrics.MetricContext;
 import software.amazon.swage.metrics.Unit;
 
-@RunWith(MockitoJUnitRunner.class)
-public class MultiRecorderTest {
+class MultiRecorderTest {
     private static final Metric METRIC = Metric.define("Metric");
 
     @Spy private NullRecorder delegate1;
@@ -29,13 +28,14 @@ public class MultiRecorderTest {
 
     private MultiRecorder recorder;
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
+        MockitoAnnotations.openMocks(this);
         recorder = new MultiRecorder(Arrays.asList(delegate1, delegate2));
     }
 
     @Test
-    public void recordIsSentToAllDelegates() {
+    void recordIsSentToAllDelegates() {
         MetricContext context = recorder.context(attributes);
         context.record(METRIC, 42L, Unit.NONE, timestamp);
         verify(delegate1).record(eq(METRIC), eq(42L), eq(Unit.NONE), eq(timestamp), argThat(t -> attributes == t.attributes()));
@@ -43,7 +43,7 @@ public class MultiRecorderTest {
     }
 
     @Test
-    public void countIsSentToAllDelegates() {
+    void countIsSentToAllDelegates() {
         MetricContext context = recorder.context(attributes);
         context.count(METRIC, 42L);
         verify(delegate1).count(eq(METRIC), eq(42L), argThat(t -> attributes == t.attributes()));
@@ -51,7 +51,7 @@ public class MultiRecorderTest {
     }
 
     @Test
-    public void closeIsSentToAllDelegates() {
+    void closeIsSentToAllDelegates() {
         MetricContext context = recorder.context(attributes);
         context.close();
         verify(delegate1).close(argThat(t -> attributes == t.attributes()));

--- a/metrics-api/src/test/java/software/amazon/swage/metrics/record/NullRecorderTest.java
+++ b/metrics-api/src/test/java/software/amazon/swage/metrics/record/NullRecorderTest.java
@@ -1,15 +1,15 @@
 package software.amazon.swage.metrics.record;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
 import software.amazon.swage.collection.TypedMap;
 import software.amazon.swage.metrics.MetricContext;
 
-public class NullRecorderTest {
+class NullRecorderTest {
 
     @Test
-    public void contextReturnsAttributes() {
+    void contextReturnsAttributes() {
         TypedMap attributes = TypedMap.empty();
         NullRecorder recorder = new NullRecorder();
         MetricContext context = recorder.context(attributes);

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -30,10 +30,11 @@
         </dependency>
 
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-bundle</artifactId>
-            <version>1.11.125</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>cloudwatch</artifactId>
+            <version>2.20.9</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
@@ -41,8 +42,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorder.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorder.java
@@ -14,14 +14,12 @@
  */
 package software.amazon.swage.metrics.record.cloudwatch;
 
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
-import com.amazonaws.services.cloudwatch.model.MetricDatum;
-import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
-import com.amazonaws.services.cloudwatch.model.StandardUnit;
-import com.amazonaws.services.cloudwatch.model.StatisticSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit;
 import software.amazon.swage.collection.TypedMap;
 import software.amazon.swage.metrics.ContextData;
 import software.amazon.swage.metrics.Metric;
@@ -102,7 +100,7 @@ public class CloudWatchRecorder extends MetricRecorder<MetricRecorder.RecorderCo
                 .build();
     }
 
-    private final AmazonCloudWatch metricsClient;
+    private final CloudWatchAsyncClient metricsClient;
     private final String namespace;
 
     private final ScheduledExecutorService publishExecutor;
@@ -113,7 +111,7 @@ public class CloudWatchRecorder extends MetricRecorder<MetricRecorder.RecorderCo
     public static final class Builder {
         private String namespace;
         private boolean autoShutdown = false;
-        private AmazonCloudWatch client;
+        private CloudWatchAsyncClient client;
         private DimensionMapper dimensionMapper = DEFAULT_DIMENSIONS;
         private int maxJitter = DEFAULT_JITTER;
         private int publishFrequency = DEFAULT_PUBLISH_FREQ;
@@ -129,7 +127,7 @@ public class CloudWatchRecorder extends MetricRecorder<MetricRecorder.RecorderCo
             return this;
         }
 
-        public Builder client(AmazonCloudWatch client) {
+        public Builder client(CloudWatchAsyncClient client) {
             this.client = client;
             return this;
         }
@@ -159,7 +157,7 @@ public class CloudWatchRecorder extends MetricRecorder<MetricRecorder.RecorderCo
                 scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
             }
             if (client == null) {
-                client = AmazonCloudWatchClientBuilder.defaultClient();
+                client = CloudWatchAsyncClient.create();
             }
             CloudWatchRecorder recorder = new CloudWatchRecorder(
                     client,
@@ -237,7 +235,7 @@ public class CloudWatchRecorder extends MetricRecorder<MetricRecorder.RecorderCo
      * @param namespace CloudWatch namespace to publish under
      */
     public CloudWatchRecorder(
-            final AmazonCloudWatch client,
+            final CloudWatchAsyncClient client,
             final String namespace)
     {
         this(client, namespace, DEFAULT_JITTER, DEFAULT_PUBLISH_FREQ, DEFAULT_DIMENSIONS);
@@ -265,7 +263,7 @@ public class CloudWatchRecorder extends MetricRecorder<MetricRecorder.RecorderCo
      *                        to CloudWatch for each metric event.
      */
     public CloudWatchRecorder(
-            final AmazonCloudWatch client,
+            final CloudWatchAsyncClient client,
             final String namespace,
             final int maxJitter,
             final int publishFrequency,
@@ -303,7 +301,7 @@ public class CloudWatchRecorder extends MetricRecorder<MetricRecorder.RecorderCo
      * @param scheduledExecutorService Executor to schedule metric publishing at a fixed rate.
      */
     public CloudWatchRecorder(
-            final AmazonCloudWatch client,
+            final CloudWatchAsyncClient client,
             final String namespace,
             final int maxJitter,
             final int publishFrequency,
@@ -423,38 +421,38 @@ public class CloudWatchRecorder extends MetricRecorder<MetricRecorder.RecorderCo
         aggregator.add(context,
                        label,
                        Long.valueOf(delta).doubleValue(),
-                       StandardUnit.Count);
+                       StandardUnit.COUNT);
     }
 
     //TODO: stop propagating new Unit abstractions everywhere
     private static final Map<Unit, StandardUnit> unitMapping = new HashMap<>();
     static {
-        unitMapping.put(Unit.SECOND, StandardUnit.Seconds);
-        unitMapping.put(Unit.MILLISECOND, StandardUnit.Milliseconds);
-        unitMapping.put(Unit.MICROSECOND, StandardUnit.Microseconds);
-        unitMapping.put(Unit.BYTE, StandardUnit.Bytes);
-        unitMapping.put(Unit.KILOBYTE, StandardUnit.Kilobytes);
-        unitMapping.put(Unit.MEGABYTE, StandardUnit.Megabytes);
-        unitMapping.put(Unit.GIGABYTE, StandardUnit.Gigabytes);
-        unitMapping.put(Unit.TERABYTE, StandardUnit.Terabytes);
-        unitMapping.put(Unit.BIT, StandardUnit.Bits);
-        unitMapping.put(Unit.KILOBIT, StandardUnit.Kilobits);
-        unitMapping.put(Unit.MEGABIT, StandardUnit.Megabits);
-        unitMapping.put(Unit.GIGABIT, StandardUnit.Gigabits);
-        unitMapping.put(Unit.TERABIT, StandardUnit.Terabits);
-        unitMapping.put(Unit.PERCENT, StandardUnit.Percent);
-        unitMapping.put(Unit.BYTE_PER_SEC, StandardUnit.BytesSecond);
-        unitMapping.put(Unit.KB_PER_SEC, StandardUnit.KilobytesSecond);
-        unitMapping.put(Unit.MB_PER_SEC, StandardUnit.MegabytesSecond);
-        unitMapping.put(Unit.GB_PER_SEC, StandardUnit.GigabytesSecond);
-        unitMapping.put(Unit.TB_PER_SEC, StandardUnit.TerabytesSecond);
-        unitMapping.put(Unit.BIT_PER_SEC, StandardUnit.BitsSecond);
-        unitMapping.put(Unit.KBIT_PER_SEC, StandardUnit.KilobitsSecond);
-        unitMapping.put(Unit.MBIT_PER_SEC, StandardUnit.MegabitsSecond);
-        unitMapping.put(Unit.GBIT_PER_SEC, StandardUnit.GigabitsSecond);
-        unitMapping.put(Unit.TBIT_PER_SEC, StandardUnit.TerabitsSecond);
-        unitMapping.put(Unit.PER_SEC, StandardUnit.CountSecond);
-        unitMapping.put(Unit.NONE, StandardUnit.None);
+        unitMapping.put(Unit.SECOND, StandardUnit.SECONDS);
+        unitMapping.put(Unit.MILLISECOND, StandardUnit.MILLISECONDS);
+        unitMapping.put(Unit.MICROSECOND, StandardUnit.MICROSECONDS);
+        unitMapping.put(Unit.BYTE, StandardUnit.BYTES);
+        unitMapping.put(Unit.KILOBYTE, StandardUnit.KILOBYTES);
+        unitMapping.put(Unit.MEGABYTE, StandardUnit.MEGABYTES);
+        unitMapping.put(Unit.GIGABYTE, StandardUnit.GIGABYTES);
+        unitMapping.put(Unit.TERABYTE, StandardUnit.TERABYTES);
+        unitMapping.put(Unit.BIT, StandardUnit.BITS);
+        unitMapping.put(Unit.KILOBIT, StandardUnit.KILOBITS);
+        unitMapping.put(Unit.MEGABIT, StandardUnit.MEGABITS);
+        unitMapping.put(Unit.GIGABIT, StandardUnit.GIGABITS);
+        unitMapping.put(Unit.TERABIT, StandardUnit.TERABITS);
+        unitMapping.put(Unit.PERCENT, StandardUnit.PERCENT);
+        unitMapping.put(Unit.BYTE_PER_SEC, StandardUnit.BYTES_SECOND);
+        unitMapping.put(Unit.KB_PER_SEC, StandardUnit.KILOBYTES_SECOND);
+        unitMapping.put(Unit.MB_PER_SEC, StandardUnit.MEGABYTES_SECOND);
+        unitMapping.put(Unit.GB_PER_SEC, StandardUnit.GIGABYTES_SECOND);
+        unitMapping.put(Unit.TB_PER_SEC, StandardUnit.TERABYTES_SECOND);
+        unitMapping.put(Unit.BIT_PER_SEC, StandardUnit.BITS_SECOND);
+        unitMapping.put(Unit.KBIT_PER_SEC, StandardUnit.KILOBITS_SECOND);
+        unitMapping.put(Unit.MBIT_PER_SEC, StandardUnit.MEGABITS_SECOND);
+        unitMapping.put(Unit.GBIT_PER_SEC, StandardUnit.GIGABITS_SECOND);
+        unitMapping.put(Unit.TBIT_PER_SEC, StandardUnit.TERABITS_SECOND);
+        unitMapping.put(Unit.PER_SEC, StandardUnit.COUNT_SECOND);
+        unitMapping.put(Unit.NONE, StandardUnit.NONE);
     }
 
     private void sendAggregatedData() {
@@ -482,10 +480,11 @@ public class CloudWatchRecorder extends MetricRecorder<MetricRecorder.RecorderCo
 
     //TODO: ensure "Each PutMetricData request is limited to 40 KB in size for HTTP POST requests."
     private void sendData( Collection<MetricDatum> metricData ) {
-        PutMetricDataRequest request = new PutMetricDataRequest();
-        request.setNamespace( namespace );
-        request.setMetricData( metricData );
-        metricsClient.putMetricData( request );
+        PutMetricDataRequest request = PutMetricDataRequest.builder()
+                .namespace(namespace)
+                .metricData(metricData)
+                .build();
+        metricsClient.putMetricData(request);
     }
 
     static boolean isValid(final Metric label) {

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/record/cloudwatch/DimensionMapper.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/record/cloudwatch/DimensionMapper.java
@@ -20,7 +20,15 @@ import software.amazon.swage.collection.TypedMap;
 import software.amazon.swage.metrics.Metric;
 import software.amazon.swage.metrics.record.MetricRecorder;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/metrics-core/src/main/java/software/amazon/swage/metrics/record/cloudwatch/DimensionMapper.java
+++ b/metrics-core/src/main/java/software/amazon/swage/metrics/record/cloudwatch/DimensionMapper.java
@@ -14,21 +14,13 @@
  */
 package software.amazon.swage.metrics.record.cloudwatch;
 
-import com.amazonaws.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
 import software.amazon.swage.collection.ImmutableTypedMap;
 import software.amazon.swage.collection.TypedMap;
 import software.amazon.swage.metrics.Metric;
 import software.amazon.swage.metrics.record.MetricRecorder;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -146,9 +138,9 @@ public class DimensionMapper {
         }
 
         Stream<TypedMap.Key> keys = Stream.concat(globalDimensions.stream(), dimensionKeys.stream());
-        return keys.map(key -> new Dimension().withName(key.name).withValue(String.valueOf(attributes.get(key))))
+        return keys.map(key -> Dimension.builder().name(key.name).value(String.valueOf(attributes.get(key))).build())
             .distinct()
-            .sorted(Comparator.comparing(Dimension::getName))
+            .sorted(Comparator.comparing(Dimension::name))
             .collect(Collectors.toList());
     }
 

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/StandardMetricTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/StandardMetricTest.java
@@ -14,9 +14,9 @@
  */
 package software.amazon.swage.metrics;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class StandardMetricTest {
+class StandardMetricTest {
 
     /*
      * Basic unit test to load the StandardMetric class and run validation on the
@@ -24,7 +24,7 @@ public class StandardMetricTest {
      * load/runtime.
      */
     @Test
-    public void validate() throws Exception {
+    void validate() {
         // Reference one member to force loading all static members.
         // Simpler than doing so explicitly ourselves.
         final Metric time = StandardMetric.TIME;

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/jmx/MXBeanPollerTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/jmx/MXBeanPollerTest.java
@@ -20,10 +20,10 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.atLeastOnce;
@@ -39,7 +39,7 @@ import software.amazon.swage.metrics.record.NullRecorder;
 
 /**
  */
-public class MXBeanPollerTest {
+class MXBeanPollerTest {
 
     // A matcher that checks the given TypedMap contains the minimal information
     // expected to be added by MXBeanPoller.
@@ -55,8 +55,8 @@ public class MXBeanPollerTest {
     }
 
     @Test
-    public void senses() throws Exception {
-        final MetricRecorder recorder = new NullRecorder();
+    void senses() throws Exception {
+        final MetricRecorder<?> recorder = new NullRecorder();
 
         final Sensor sensor1 = mock(Sensor.class);
         final Sensor sensor2 = mock(Sensor.class);
@@ -79,12 +79,12 @@ public class MXBeanPollerTest {
     }
 
     @Test
-    public void shutdown() throws Exception {
+    void shutdown() {
         final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
         MXBeanPoller poller = new MXBeanPoller(executor, new NullRecorder(), 5, Collections.emptyList());
         poller.shutdown();
 
-        assertTrue("Executor not shutdown on poller shutdown", executor.isShutdown());
+        assertTrue(executor.isShutdown(), "Executor not shutdown on poller shutdown");
     }
 }

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/jmx/sensor/HeapMemoryAfterGCSensorTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/jmx/sensor/HeapMemoryAfterGCSensorTest.java
@@ -3,12 +3,16 @@ package software.amazon.swage.metrics.jmx.sensor;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryUsage;
 import java.util.Arrays;
+import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import software.amazon.swage.metrics.MetricContext;
 import software.amazon.swage.metrics.Unit;
 
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -17,72 +21,73 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static software.amazon.swage.metrics.jmx.sensor.HeapMemoryAfterGCSensor.HEAP_AFTER_GC_USE;
 
-public class HeapMemoryAfterGCSensorTest {
+class HeapMemoryAfterGCSensorTest {
     private static final String OLD_MEM_POOL = "OldPool";
     private static final String EDEN_MEM_POOL = "EdenPool";
     private static final String TENURED_MEM_POOL = "TenuredPool";
 
     private MetricContext metricContext;
 
-    @Before
-    public void initialize() {
+    @BeforeEach
+    void initialize() {
         metricContext = mock(MetricContext.class);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void sense_withNullMemoryPoolList_throwsIllegalStateException() {
-        new HeapMemoryAfterGCSensor(() -> null).sense(metricContext);
+    @Test
+    void sense_withNullMemoryPoolList_throwsIllegalStateException() {
+        Executable test = () -> new HeapMemoryAfterGCSensor(() -> null).sense(metricContext);
+        assertThrows(IllegalStateException.class, test);
     }
 
     @Test
-    public void sense_withNoMemoryPools_doesNotRecordMetric() {
+    void sense_withNoMemoryPools_doesNotRecordMetric() {
         final HeapMemoryAfterGCSensor sensor =
-                new HeapMemoryAfterGCSensor(() -> Arrays.asList());
+                new HeapMemoryAfterGCSensor(Collections::emptyList);
         sensor.sense(metricContext);
 
         verify(metricContext, never()).record(any(), any(), any());
     }
 
     @Test
-    public void sense_withNullLongLivedMemoryPoolData_doesNotRecordMetric() {
+    void sense_withNullLongLivedMemoryPoolData_doesNotRecordMetric() {
         final MemoryPoolMXBean oldMemPoolWithNullData = mock(MemoryPoolMXBean.class);
         when(oldMemPoolWithNullData.getName()).thenReturn(OLD_MEM_POOL);
         when(oldMemPoolWithNullData.getCollectionUsage()).thenReturn(null);
 
         final HeapMemoryAfterGCSensor sensor =
-                new HeapMemoryAfterGCSensor(() -> Arrays.asList(oldMemPoolWithNullData));
+                new HeapMemoryAfterGCSensor(() -> singletonList(oldMemPoolWithNullData));
         sensor.sense(metricContext);
 
         verify(metricContext, never()).record(any(), any(), any());
     }
 
     @Test
-    public void sense_withMemoryPoolWithoutName_doesNotRecordMetric() {
+    void sense_withMemoryPoolWithoutName_doesNotRecordMetric() {
         final MemoryPoolMXBean memPoolWithNullName = mock(MemoryPoolMXBean.class);
         when(memPoolWithNullName.getName()).thenReturn(null);
 
         final HeapMemoryAfterGCSensor sensor =
-                new HeapMemoryAfterGCSensor(() -> Arrays.asList(memPoolWithNullName));
+                new HeapMemoryAfterGCSensor(() -> singletonList(memPoolWithNullName));
         sensor.sense(metricContext);
 
         verify(metricContext, never()).record(any(), any(), any());
     }
 
     @Test
-    public void sense_withNoLongLivedMemory_doesNotRecordMetric() {
+    void sense_withNoLongLivedMemory_doesNotRecordMetric() {
         final long usedMem = 1024L;
         final long totalMem = 10240L;
         final MemoryPoolMXBean edenMemPool = setupMemoryPoolData(EDEN_MEM_POOL, usedMem, totalMem);
 
         final HeapMemoryAfterGCSensor sensor =
-                new HeapMemoryAfterGCSensor(() -> Arrays.asList(edenMemPool));
+                new HeapMemoryAfterGCSensor(() -> singletonList(edenMemPool));
         sensor.sense(metricContext);
 
         verify(metricContext, never()).record(any(), any(), any());
     }
 
     @Test
-    public void sense_withSingleLongLivedMemoryPool_recordsSingleMetric() {
+    void sense_withSingleLongLivedMemoryPool_recordsSingleMetric() {
         final long usedMem = 1024L;
         final long totalMem = 10240L;
         final double expectedUseMetric = 100.0 * usedMem / totalMem;
@@ -90,28 +95,28 @@ public class HeapMemoryAfterGCSensorTest {
         final MemoryPoolMXBean oldMemPool = setupMemoryPoolData(OLD_MEM_POOL, usedMem, totalMem);
 
         final HeapMemoryAfterGCSensor sensor =
-                new HeapMemoryAfterGCSensor(() -> Arrays.asList(oldMemPool));
+                new HeapMemoryAfterGCSensor(() -> singletonList(oldMemPool));
         sensor.sense(metricContext);
 
         verify(metricContext, times(1)).record(HEAP_AFTER_GC_USE, expectedUseMetric, Unit.PERCENT);
     }
 
     @Test
-    public void sense_withSingleLongLivedMemoryPoolButUndefinedMax_doesNotRecordMetric() {
+    void sense_withSingleLongLivedMemoryPoolButUndefinedMax_doesNotRecordMetric() {
         final long usedMem = 1024L;
         final long totalMem = -1L;
 
         final MemoryPoolMXBean oldMemPool = setupMemoryPoolData(OLD_MEM_POOL, usedMem, totalMem);
 
         final HeapMemoryAfterGCSensor sensor =
-                new HeapMemoryAfterGCSensor(() -> Arrays.asList(oldMemPool));
+                new HeapMemoryAfterGCSensor(() -> singletonList(oldMemPool));
         sensor.sense(metricContext);
 
         verify(metricContext, never()).record(any(), any(), any());
     }
 
     @Test
-    public void sense_withShortAndLongLivedMemoryPool_recordsSingleMetric() {
+    void sense_withShortAndLongLivedMemoryPool_recordsSingleMetric() {
         final long oldUsedMem = 1024L;
         final long oldTotalMem = 10240L;
         final long edenUsedMem = 2048L;
@@ -129,7 +134,7 @@ public class HeapMemoryAfterGCSensorTest {
     }
 
     @Test
-    public void sense_withTwoLongLivedMemoryPools_recordsAggregateMetric() {
+    void sense_withTwoLongLivedMemoryPools_recordsAggregateMetric() {
         final long oldUsedMem = 1024L;
         final long oldTotalMem = 10240L;
         final long tenuredUsedMem = 2048L;
@@ -148,7 +153,7 @@ public class HeapMemoryAfterGCSensorTest {
     }
 
     @Test
-    public void sense_withTwoLongLivedMemoryPoolsAndOneUndefinedMax_recordsAggregateMetric() {
+    void sense_withTwoLongLivedMemoryPoolsAndOneUndefinedMax_recordsAggregateMetric() {
         final long oldUsedMem = 1024L;
         final long oldTotalMem = -1L;
         final long tenuredUsedMem = 2048L;

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorderTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorderTest.java
@@ -16,7 +16,11 @@ package software.amazon.swage.metrics.record.cloudwatch;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
-import software.amazon.awssdk.services.cloudwatch.model.*;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit;
+import software.amazon.awssdk.services.cloudwatch.model.StatisticSet;
 import software.amazon.swage.collection.TypedMap;
 import software.amazon.swage.metrics.ContextData;
 import software.amazon.swage.metrics.Metric;

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/MetricDataAggregatorTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/MetricDataAggregatorTest.java
@@ -14,10 +14,10 @@
  */
 package software.amazon.swage.metrics.record.cloudwatch;
 
-import com.amazonaws.services.cloudwatch.model.MetricDatum;
-import com.amazonaws.services.cloudwatch.model.StandardUnit;
-import com.amazonaws.services.cloudwatch.model.StatisticSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit;
+import software.amazon.awssdk.services.cloudwatch.model.StatisticSet;
 import software.amazon.swage.metrics.ContextData;
 import software.amazon.swage.metrics.Metric;
 import software.amazon.swage.metrics.record.MetricRecorder;
@@ -25,9 +25,9 @@ import software.amazon.swage.metrics.record.MetricRecorder;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class MetricDataAggregatorTest {
 
@@ -37,14 +37,14 @@ public class MetricDataAggregatorTest {
     private static final Metric D = Metric.define("D");
 
     @Test
-    public void single() throws Exception {
+    public void single() {
         final DimensionMapper mapper = new DimensionMapper.Builder()
                 .addGlobalDimension(ContextData.ID)
                 .build();
 
         final Metric name = Metric.define("SomeMetric");
         final double value = 3.14;
-        final StandardUnit unit = StandardUnit.Terabits;
+        final StandardUnit unit = StandardUnit.TERABITS;
 
         final MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(ContextData.withId(UUID.randomUUID().toString()).build());
 
@@ -53,29 +53,29 @@ public class MetricDataAggregatorTest {
 
         List<MetricDatum> ags = aggregator.flush();
 
-        assertEquals("One metric datum should aggregate to one entry", 1, ags.size());
-        assertEquals("Metric datum has wrong name", name.toString(), ags.get(0).getMetricName());
-        assertEquals("Metric datum has wrong unit", unit.toString(), ags.get(0).getUnit());
+        assertEquals(1, ags.size(), "One metric datum should aggregate to one entry");
+        assertEquals(name.toString(), ags.get(0).metricName(), "Metric datum has wrong name");
+        assertEquals(unit, ags.get(0).unit(), "Metric datum has wrong unit");
 
-        StatisticSet stats = ags.get(0).getStatisticValues();
-        assertEquals("Metric datum has wrong stats value", Double.valueOf(value), stats.getSum());
-        assertEquals("Metric datum has wrong stats value", Double.valueOf(value), stats.getMinimum());
-        assertEquals("Metric datum has wrong stats value", Double.valueOf(value), stats.getMaximum());
-        assertEquals("Metric datum has wrong stats count", Double.valueOf(1), stats.getSampleCount());
+        StatisticSet stats = ags.get(0).statisticValues();
+        assertEquals(Double.valueOf(value), stats.sum(), "Metric datum has wrong stats value");
+        assertEquals(Double.valueOf(value), stats.minimum(), "Metric datum has wrong stats value");
+        assertEquals(Double.valueOf(value), stats.maximum(), "Metric datum has wrong stats value");
+        assertEquals(Double.valueOf(1), stats.sampleCount(), "Metric datum has wrong stats count");
 
-        assertTrue("Flush with no attributes was non-empty", aggregator.flush().isEmpty());
+        assertTrue(aggregator.flush().isEmpty(), "Flush with no attributes was non-empty");
     }
 
 
     @Test
-    public void non_aggregated() throws Exception {
+    public void non_aggregated() {
         final DimensionMapper mapper = new DimensionMapper.Builder()
                 .addGlobalDimension(ContextData.ID)
                 .build();
 
         final Metric[] names = {A, B, C, D};
         final double[] values = {3.14, 6.28, 0, 9};
-        final StandardUnit[] units = {StandardUnit.Seconds, StandardUnit.Terabits, StandardUnit.Seconds, StandardUnit.Milliseconds};
+        final StandardUnit[] units = {StandardUnit.SECONDS, StandardUnit.TERABITS, StandardUnit.SECONDS, StandardUnit.MILLISECONDS};
 
         final MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(ContextData.withId(UUID.randomUUID().toString()).build());
 
@@ -86,29 +86,29 @@ public class MetricDataAggregatorTest {
 
         List<MetricDatum> ags = aggregator.flush();
 
-        assertEquals("Metric attributes hs wrong size", names.length, ags.size());
+        assertEquals(names.length, ags.size(), "Metric attributes hs wrong size");
         for (MetricDatum d : ags) {
             int i = 0;
-            while (i < names.length && !names[i].toString().equals(d.getMetricName())) {
+            while (i < names.length && !names[i].toString().equals(d.metricName())) {
                 i++;
             }
-            assertTrue("Aggregated metrics had unexpected datum", i<names.length);
+            assertTrue(i<names.length, "Aggregated metrics had unexpected datum");
 
-            assertEquals("Metric datum has wrong name", names[i].toString(), d.getMetricName());
-            assertEquals("Metric datum has wrong unit", units[i].toString(), d.getUnit());
+            assertEquals(names[i].toString(), d.metricName(), "Metric datum has wrong name");
+            assertEquals(units[i], d.unit(), "Metric datum has wrong unit");
 
-            StatisticSet stats = d.getStatisticValues();
-            assertEquals("Metric datum has wrong stats value", Double.valueOf(values[i]), stats.getSum());
-            assertEquals("Metric datum has wrong stats value", Double.valueOf(values[i]), stats.getMinimum());
-            assertEquals("Metric datum has wrong stats value", Double.valueOf(values[i]), stats.getMaximum());
-            assertEquals("Metric datum has wrong stats count", Double.valueOf(1), stats.getSampleCount());
+            StatisticSet stats = d.statisticValues();
+            assertEquals(Double.valueOf(values[i]), stats.sum(), "Metric datum has wrong stats value");
+            assertEquals(Double.valueOf(values[i]), stats.minimum(), "Metric datum has wrong stats value");
+            assertEquals(Double.valueOf(values[i]), stats.maximum(), "Metric datum has wrong stats value");
+            assertEquals(Double.valueOf(1), stats.sampleCount(), "Metric datum has wrong stats count");
         }
 
-        assertTrue("Flush with no attributes was non-empty", aggregator.flush().isEmpty());
+        assertTrue(aggregator.flush().isEmpty(), "Flush with no attributes was non-empty");
     }
 
     @Test
-    public void aggregate() throws Exception {
+    public void aggregate() {
         final DimensionMapper mapper = new DimensionMapper.Builder()
                 .addGlobalDimension(ContextData.ID)
                 .build();
@@ -116,13 +116,13 @@ public class MetricDataAggregatorTest {
         final Metric[] names = {D, A, B, A, D, D, D};
         final double[] values = {42, 3.14, 6.28, 0, 9, 2, 4.1};
         final StandardUnit[] units = {
-                StandardUnit.Milliseconds,
-                StandardUnit.Seconds,
-                StandardUnit.Terabits,
-                StandardUnit.Seconds,
-                StandardUnit.Milliseconds,
-                StandardUnit.Percent,
-                StandardUnit.Milliseconds};
+                StandardUnit.MILLISECONDS,
+                StandardUnit.SECONDS,
+                StandardUnit.TERABITS,
+                StandardUnit.SECONDS,
+                StandardUnit.MILLISECONDS,
+                StandardUnit.PERCENT,
+                StandardUnit.MILLISECONDS};
 
         final MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(ContextData.withId(UUID.randomUUID().toString()).build());
 
@@ -133,39 +133,39 @@ public class MetricDataAggregatorTest {
 
         List<MetricDatum> ags = aggregator.flush();
 
-        assertEquals("Metric attributes hs wrong size", 4, ags.size());
+        assertEquals(4, ags.size(), "Metric attributes hs wrong size");
         boolean[] seen = {false, false, false, false};
         for (MetricDatum d : ags) {
-            if (d.getMetricName().equals(A.toString()) && d.getUnit().equals(StandardUnit.Seconds.toString())) {
-                StatisticSet stats = d.getStatisticValues();
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(3.14+0), stats.getSum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(0), stats.getMinimum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(3.14), stats.getMaximum());
-                assertEquals("Aggregated metric has wrong stats count", Double.valueOf(2), stats.getSampleCount());
+            if (d.metricName().equals(A.toString()) && d.unit().equals(StandardUnit.SECONDS)) {
+                StatisticSet stats = d.statisticValues();
+                assertEquals(Double.valueOf(3.14+0), stats.sum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(0), stats.minimum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(3.14), stats.maximum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(2), stats.sampleCount(), "Aggregated metric has wrong stats count");
                 seen[0] = true;
             }
-            else if (d.getMetricName().equals(B.toString()) && d.getUnit().equals(StandardUnit.Terabits.toString())) {
-                StatisticSet stats = d.getStatisticValues();
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(6.28), stats.getSum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(6.28), stats.getMinimum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(6.28), stats.getMaximum());
-                assertEquals("Aggregated metric has wrong stats count", Double.valueOf(1), stats.getSampleCount());
+            else if (d.metricName().equals(B.toString()) && d.unit().equals(StandardUnit.TERABITS)) {
+                StatisticSet stats = d.statisticValues();
+                assertEquals(Double.valueOf(6.28), stats.sum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(6.28), stats.minimum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(6.28), stats.maximum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(1), stats.sampleCount(), "Aggregated metric has wrong stats count");
                 seen[1] = true;
             }
-            else if (d.getMetricName().equals(D.toString()) && d.getUnit().equals(StandardUnit.Milliseconds.toString())) {
-                StatisticSet stats = d.getStatisticValues();
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(42+9+4.1), stats.getSum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(4.1), stats.getMinimum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(42), stats.getMaximum());
-                assertEquals("Aggregated metric has wrong stats count", Double.valueOf(3), stats.getSampleCount());
+            else if (d.metricName().equals(D.toString()) && d.unit().equals(StandardUnit.MILLISECONDS)) {
+                StatisticSet stats = d.statisticValues();
+                assertEquals(Double.valueOf(42+9+4.1), stats.sum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(4.1), stats.minimum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(42), stats.maximum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(3), stats.sampleCount(), "Aggregated metric has wrong stats count");
                 seen[2] = true;
             }
-            else if (d.getMetricName().equals(D.toString()) && d.getUnit().equals(StandardUnit.Percent.toString())) {
-                StatisticSet stats = d.getStatisticValues();
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(2), stats.getSum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(2), stats.getMinimum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(2), stats.getMaximum());
-                assertEquals("Aggregated metric has wrong stats count", Double.valueOf(1), stats.getSampleCount());
+            else if (d.metricName().equals(D.toString()) && d.unit().equals(StandardUnit.PERCENT)) {
+                StatisticSet stats = d.statisticValues();
+                assertEquals(Double.valueOf(2), stats.sum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(2), stats.minimum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(2), stats.maximum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(1), stats.sampleCount(), "Aggregated metric has wrong stats count");
                 seen[3] = true;
             }
             else {
@@ -173,52 +173,52 @@ public class MetricDataAggregatorTest {
             }
         }
         for (int i=0; i<seen.length; i++) {
-            assertTrue("Expected aggregated metric not seen", seen[i]);
+            assertTrue(seen[i], "Expected aggregated metric not seen");
         }
 
-        assertTrue("Flush with no attributes was non-empty", aggregator.flush().isEmpty());
+        assertTrue(aggregator.flush().isEmpty(), "Flush with no attributes was non-empty");
 
         // Now add more attributes, but let's just do two this time
         for (int i=0; i<5; i++) {
-            aggregator.add(context, A, i, StandardUnit.Count);
+            aggregator.add(context, A, i, StandardUnit.COUNT);
         }
         Metric other = Metric.define("Other");
         double osum = 0;
         for (int i=0; i<12; i++) {
             osum += 0.01*i;
-            aggregator.add(context, other, 0.01*i, StandardUnit.Terabits);
+            aggregator.add(context, other, 0.01*i, StandardUnit.TERABITS);
         }
 
         ags = aggregator.flush();
 
-        assertEquals("Metric attributes hs wrong size", 2, ags.size());
+        assertEquals(2, ags.size(), "Metric attributes hs wrong size");
         boolean seenA = false;
         boolean seenO = false;
         for (MetricDatum d : ags) {
-            if (d.getMetricName().equals(A.toString()) && d.getUnit().equals(StandardUnit.Count.toString())) {
-                StatisticSet stats = d.getStatisticValues();
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(0+1+2+3+4), stats.getSum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(0), stats.getMinimum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(4), stats.getMaximum());
-                assertEquals("Aggregated metric has wrong stats count", Double.valueOf(5), stats.getSampleCount());
+            if (d.metricName().equals(A.toString()) && d.unit().equals(StandardUnit.COUNT)) {
+                StatisticSet stats = d.statisticValues();
+                assertEquals(Double.valueOf(0+1+2+3+4), stats.sum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(0), stats.minimum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(4), stats.maximum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(5), stats.sampleCount(), "Aggregated metric has wrong stats count");
                 seenA = true;
             }
-            else if (d.getMetricName().equals(other.toString()) && d.getUnit().equals(StandardUnit.Terabits.toString())) {
-                StatisticSet stats = d.getStatisticValues();
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(osum), stats.getSum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(0), stats.getMinimum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(0.11), stats.getMaximum());
-                assertEquals("Aggregated metric has wrong stats count", Double.valueOf(12), stats.getSampleCount());
+            else if (d.metricName().equals(other.toString()) && d.unit().equals(StandardUnit.TERABITS)) {
+                StatisticSet stats = d.statisticValues();
+                assertEquals(Double.valueOf(osum), stats.sum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(0), stats.minimum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(0.11), stats.maximum(), "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(12), stats.sampleCount(), "Aggregated metric has wrong stats count");
                 seenO = true;
             }
             else {
                 fail("Unexpected metric returned in aggregated set");
             }
         }
-        assertTrue("Expected aggregated metric not seen", seenA);
-        assertTrue("Expected aggregated metric not seen", seenO);
+        assertTrue(seenA, "Expected aggregated metric not seen");
+        assertTrue(seenO, "Expected aggregated metric not seen");
 
-        assertTrue("Flush with no attributes was non-empty", aggregator.flush().isEmpty());
+        assertTrue(aggregator.flush().isEmpty(), "Flush with no attributes was non-empty");
     }
 
 }

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/record/file/FileRecorderTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/record/file/FileRecorderTest.java
@@ -1,11 +1,11 @@
 package software.amazon.swage.metrics.record.file;
 
-import org.junit.Test;
 
+import org.junit.jupiter.api.Test;
 import software.amazon.swage.metrics.Metric;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FileRecorderTest {
     @Test
@@ -21,7 +21,7 @@ public class FileRecorderTest {
             "\t!\"#$%&'()*+./;<>?@[\\]^`{|}~" // no ',' ':' '\n'
         };
         for (final String s : good) {
-            assertTrue("valid name [" + s + "]", FileRecorder.isValid(Metric.define(s)));
+            assertTrue(FileRecorder.isValid(Metric.define(s)), "valid name [" + s + "]");
         }
 
         final String[] bad = {
@@ -32,7 +32,7 @@ public class FileRecorderTest {
             "metric=metric_name"
         };
         for (final String s : bad) {
-            assertFalse("invalid name [" + s + "]", FileRecorder.isValid(Metric.define(s)));
+            assertFalse(FileRecorder.isValid(Metric.define(s)), "invalid name [" + s + "]");
         }
     }
 }

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/record/file/RollingFileWriterTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/record/file/RollingFileWriterTest.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.swage.metrics.record.file;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -25,8 +25,9 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.TimeZone;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for the RollingFileWriter.
@@ -58,19 +59,20 @@ public class RollingFileWriterTest {
                 .format(LocalDateTime.ofInstant(Instant.now().truncatedTo(ChronoUnit.MINUTES), tz.toZoneId()));
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void nullDir() throws Exception {
-        new RollingFileWriter(null, "foo");
+    @Test
+    public void nullDir() {
+        assertThrows(IllegalArgumentException.class, () -> new RollingFileWriter(null, "foo"));
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void nullName() throws Exception {
-        new RollingFileWriter(testDir, null);
+    @Test
+    public void nullName() {
+        assertThrows(IllegalArgumentException.class, () -> new RollingFileWriter(testDir, null));
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void nullZone() throws Exception {
-        new RollingFileWriter(testDir, "bar", null, false);
+    @Test
+    public void nullZone() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new RollingFileWriter(testDir, "bar", null, false));
     }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,14 +91,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13.1</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>5.9.2</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.7.22</version>
+                <version>4.11.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/thread-context/pom.xml
+++ b/thread-context/pom.xml
@@ -20,8 +20,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/thread-context/src/test/java/software/amazon/swage/threadcontext/ContextAwareExecutorTest.java
+++ b/thread-context/src/test/java/software/amazon/swage/threadcontext/ContextAwareExecutorTest.java
@@ -14,16 +14,16 @@
  */
 package software.amazon.swage.threadcontext;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-public class ContextAwareExecutorTest {
+class ContextAwareExecutorTest {
     private static final ThreadContext.Key<String> KEY = ThreadContext.key(String.class);
     private static final Executor executor = new ContextAwareExecutor(Executors.newSingleThreadExecutor());
 
@@ -37,7 +37,7 @@ public class ContextAwareExecutorTest {
     };
 
     @Test
-    public void currentContextIsPropagatedToTask() throws Exception {
+    void currentContextIsPropagatedToTask() throws Exception {
         ThreadContext context = ThreadContext.emptyContext().with(KEY, "value");
         try (ThreadContext.CloseableContext ignored = context.open()) {
             executor.execute(captureTask);
@@ -47,7 +47,7 @@ public class ContextAwareExecutorTest {
     }
 
     @Test
-    public void withNoContextDefaultIsUsed() throws Exception {
+    void withNoContextDefaultIsUsed() throws Exception {
         executor.execute(captureTask);
         latch.await();
         assertSame(ThreadContext.emptyContext(), contextCapture.get());

--- a/thread-context/src/test/java/software/amazon/swage/threadcontext/ThreadContextTest.java
+++ b/thread-context/src/test/java/software/amazon/swage/threadcontext/ThreadContextTest.java
@@ -14,50 +14,50 @@
  */
 package software.amazon.swage.threadcontext;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 
-public class ThreadContextTest {
+class ThreadContextTest {
 
     private static final ThreadContext.Key<String> REQUEST_ID = ThreadContext.key(String.class);
     private static final ThreadContext.Key<String> TRACE_ID = ThreadContext.key(String.class);
     private static final ThreadContext.Key<Double> HEIGHT = ThreadContext.key(Double.class);
 
     @Test
-    public void withNoActiveContextAnEmptyContextIsReturned() {
+    void withNoActiveContextAnEmptyContextIsReturned() {
         ThreadContext context = ThreadContext.current();
         assertSame(ThreadContext.emptyContext(), context);
     }
 
     @Test
-    public void contextReturnsValueForKey() {
+    void contextReturnsValueForKey() {
         ThreadContext context = ThreadContext.emptyContext().with(REQUEST_ID, "hello");
         assertEquals("hello", REQUEST_ID.get(context));
     }
 
     @Test
-    public void contextReturnsNullForMissingKey() {
+    void contextReturnsNullForMissingKey() {
         ThreadContext context = ThreadContext.emptyContext().with(REQUEST_ID, "hello");
         assertNull(TRACE_ID.get(context));
     }
 
     @Test
-    public void defaultIsSuppliedForMissingKey() {
+    void defaultIsSuppliedForMissingKey() {
         ThreadContext context = ThreadContext.emptyContext();
         assertEquals("hello", context.getOrElseGet(REQUEST_ID, () -> "hello"));
     }
 
     @Test
-    public void keyValuesAreAdditive() {
+    void keyValuesAreAdditive() {
         ThreadContext empty = ThreadContext.emptyContext();
         ThreadContext oneKey = empty.with(REQUEST_ID, "rid");
         ThreadContext twoKey = oneKey.with(TRACE_ID, "tid");
@@ -71,7 +71,7 @@ public class ThreadContextTest {
     }
 
     @Test
-    public void keyValuesAreOverride() {
+    void keyValuesAreOverride() {
         ThreadContext oneKey = ThreadContext.emptyContext().with(REQUEST_ID, "rid1");
         ThreadContext overide = oneKey.with(REQUEST_ID, "rid2");
 
@@ -80,7 +80,7 @@ public class ThreadContextTest {
     }
 
     @Test
-    public void multipleValuesCanBeAdded() {
+    void multipleValuesCanBeAdded() {
         Double h = Double.valueOf(3.14159);
 
         Map<ThreadContext.Key, Object> values = new HashMap<>();
@@ -95,14 +95,14 @@ public class ThreadContextTest {
     }
 
     @Test
-    public void contextIsPassedToRunnable() {
+    void contextIsPassedToRunnable() {
         ThreadContext context = ThreadContext.emptyContext().with(REQUEST_ID, "rid");
         context.wrap(() -> assertSame(context, ThreadContext.current())).run();
         assertSame(ThreadContext.emptyContext(), ThreadContext.current());
     }
 
     @Test
-    public void contextIsPassedToCallable() throws Exception {
+    void contextIsPassedToCallable() throws Exception {
         ThreadContext context = ThreadContext.emptyContext().with(REQUEST_ID, "rid");
         String result = context.wrap((Callable<String>)() -> {
             assertSame(context, ThreadContext.current());
@@ -113,7 +113,7 @@ public class ThreadContextTest {
     }
 
     @Test
-    public void contextIsPassedToSupplier() throws Exception {
+    void contextIsPassedToSupplier() {
         ThreadContext context = ThreadContext.emptyContext().with(REQUEST_ID, "rid");
         String result = context.wrap((Supplier<String>)() -> {
             assertSame(context, ThreadContext.current());
@@ -124,7 +124,7 @@ public class ThreadContextTest {
     }
 
     @Test
-    public void contextIsDetachedOnClose() {
+    void contextIsDetachedOnClose() {
         ThreadContext context = ThreadContext.emptyContext().with(REQUEST_ID, "rid");
         try (ThreadContext.CloseableContext ignored = context.open()) {
             assertSame(context, ThreadContext.current());
@@ -133,7 +133,7 @@ public class ThreadContextTest {
     }
 
     @Test
-    public void contextIsRestoredOnClose() {
+    void contextIsRestoredOnClose() {
         ThreadContext outer = ThreadContext.emptyContext().with(TRACE_ID, "tid");
         ThreadContext context = ThreadContext.emptyContext().with(REQUEST_ID, "rid");
         outer.wrap(() -> {
@@ -146,14 +146,14 @@ public class ThreadContextTest {
     }
 
     @Test
-    public void keyAccessesCurrentContext() {
+    void keyAccessesCurrentContext() {
         ThreadContext context = ThreadContext.emptyContext().with(REQUEST_ID, "rid");
         assertNull(REQUEST_ID.current());
         context.wrap(() -> assertEquals("rid", REQUEST_ID.current())).run();
     }
 
     @Test
-    public void wraperContextIsUsedEvenIfOuterContextExists() {
+    void wraperContextIsUsedEvenIfOuterContextExists() {
         ThreadContext outer = ThreadContext.emptyContext().with(REQUEST_ID, "rid1");
         ThreadContext inner = ThreadContext.emptyContext().with(REQUEST_ID, "rid2");
         Runnable wrapped = inner.wrap(() -> assertSame(inner, ThreadContext.current()));

--- a/type-safe/pom.xml
+++ b/type-safe/pom.xml
@@ -14,8 +14,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/type-safe/src/test/java/software/amazon/swage/collection/ImmutableTypedMapTest.java
+++ b/type-safe/src/test/java/software/amazon/swage/collection/ImmutableTypedMapTest.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.swage.collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 import java.time.Instant;
@@ -24,16 +24,16 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ImmutableTypedMapTest {
+class ImmutableTypedMapTest {
 
     @Test
-    public void get_typesafe() throws Exception {
+    void get_typesafe() {
         final TypedMap.Key<String> ka = TypedMap.key("Key1", String.class);
         final TypedMap.Key<Integer> kb = TypedMap.key("Key2", Integer.class);
 
@@ -45,18 +45,18 @@ public class ImmutableTypedMapTest {
                 .add(kb, vb)
                 .build();
 
-        assertFalse("TypedMap instance is unexpectedly empty", data.isEmpty());
-        assertEquals("TypedMap instance has wrong size", 2, data.size());
-        assertTrue("TypedMap instance missing key", data.containsKey(ka));
-        assertTrue("TypedMap instance missing key", data.containsKey(kb));
-        assertTrue("TypedMap instance missing value", data.containsValue(va));
-        assertTrue("TypedMap instance missing value", data.containsValue(vb));
-        assertEquals("TypedMap instance has wrong value for key", va, data.get(ka));
-        assertEquals("TypedMap instance has wrong value for key", vb, data.get(kb));
+        assertFalse(data.isEmpty(), "TypedMap instance is unexpectedly empty");
+        assertEquals(2, data.size(), "TypedMap instance has wrong size");
+        assertTrue(data.containsKey(ka), "TypedMap instance missing key");
+        assertTrue(data.containsKey(kb), "TypedMap instance missing key");
+        assertTrue(data.containsValue(va), "TypedMap instance missing value");
+        assertTrue(data.containsValue(vb), "TypedMap instance missing value");
+        assertEquals(va, data.get(ka), "TypedMap instance has wrong value for key");
+        assertEquals(vb, data.get(kb), "TypedMap instance has wrong value for key");
     }
 
     @Test
-    public void no_entry() throws Exception {
+    void no_entry() {
         final TypedMap.Key<String> ka = TypedMap.key("Key1", String.class);
         final TypedMap.Key<Integer> kb = TypedMap.key("Key2", Integer.class);
 
@@ -65,47 +65,41 @@ public class ImmutableTypedMapTest {
                 .with(ka, va)
                 .build();
 
-        assertNull("Get on missing key failed to return null", data.get(kb));
-        assertEquals("getOptional on missing key returned a value", Optional.empty(), data.getOptional(kb));
+        assertNull(data.get(kb), "Get on missing key failed to return null");
+        assertEquals(Optional.empty(), data.getOptional(kb), "getOptional on missing key returned a value");
 
-        assertFalse("containsKey is true for unused key", data.containsKey(kb));
-        assertFalse("containsValue is true for non-existing value", data.containsValue("nope"));
+        assertFalse(data.containsKey(kb), "containsKey is true for unused key");
+        assertFalse(data.containsValue("nope"), "containsValue is true for non-existing value");
 
         // check the rest of the map is there
-        assertFalse("TypedMap instance is unexpectedly empty", data.isEmpty());
-        assertEquals("TypedMap instance has wrong size", 1, data.size());
-        assertTrue("TypedMap instance missing key", data.containsKey(ka));
-        assertTrue("TypedMap instance missing value", data.containsValue(va));
-        assertEquals("TypedMap instance has wrong value for key", va, data.get(ka));
-        assertEquals("TypedMap instance has wrong value for key", va, data.getOptional(ka).get());
+        assertFalse(data.isEmpty(), "TypedMap instance is unexpectedly empty");
+        assertEquals(1, data.size(), "TypedMap instance has wrong size");
+        assertTrue(data.containsKey(ka), "TypedMap instance missing key");
+        assertTrue(data.containsValue(va), "TypedMap instance missing value");
+        assertEquals(va, data.get(ka), "TypedMap instance has wrong value for key");
+        assertEquals(va, data.getOptional(ka).get(), "TypedMap instance has wrong value for key");
     }
 
     @Test
-    public void empty_constant() throws Exception {
+    void empty_constant() {
         final TypedMap.Key<Instant> key = TypedMap.key("Foo", Instant.class);
 
         TypedMap empty = TypedMap.EMPTY;
 
-        assertTrue("Empty map not empty", empty.isEmpty());
-        assertEquals("Empty map has non-zero size", 0, empty.size());
-        assertNull("Empty map has a value", empty.get(key));
-        assertFalse("Empty map contains a key", empty.containsKey(key));
-        assertFalse("Empty map contains a value", empty.containsValue("something"));
-        assertTrue("Empty map has non-empty key set", empty.keySet().isEmpty());
+        assertTrue(empty.isEmpty(), "Empty map not empty");
+        assertEquals(0, empty.size(), "Empty map has non-zero size");
+        assertNull(empty.get(key), "Empty map has a value");
+        assertFalse(empty.containsKey(key), "Empty map contains a key");
+        assertFalse(empty.containsValue("something"), "Empty map contains a value");
+        assertTrue(empty.keySet().isEmpty(), "Empty map has non-empty key set");
 
         Iterator<TypedMap.Entry> it = empty.iterator();
         assertFalse(it.hasNext());
-        try {
-            it.next();
-        } catch (NoSuchElementException e) {
-            //expected
-            return;
-        }
-        fail("Expected NoSuchElementException not thrown iterating on empty map");
+        assertThrows(NoSuchElementException.class, it::next);
     }
 
     @Test
-    public void keyset() throws Exception {
+    void keyset() throws Exception {
         final TypedMap.Key<Double> ka = TypedMap.key("Alpha", Double.class);
         final TypedMap.Key<String> kb = TypedMap.key("Beta", String.class);
         final TypedMap.Key<UUID> kc = TypedMap.key("Gamma", UUID.class);
@@ -124,15 +118,15 @@ public class ImmutableTypedMapTest {
                 .build();
 
         Set<TypedMap.Key> s = data.keySet();
-        assertEquals("Set of keys has wrong size", 4, s.size());
-        assertTrue("Set of keys is missing a key", s.contains(ka));
-        assertTrue("Set of keys is missing a key", s.contains(kb));
-        assertTrue("Set of keys is missing a key", s.contains(kc));
-        assertTrue("Set of keys is missing a key", s.contains(kd));
+        assertEquals(4, s.size(), "Set of keys has wrong size");
+        assertTrue(s.contains(ka), "Set of keys is missing a key");
+        assertTrue(s.contains(kb), "Set of keys is missing a key");
+        assertTrue(s.contains(kc), "Set of keys is missing a key");
+        assertTrue(s.contains(kd), "Set of keys is missing a key");
     }
 
     @Test
-    public void typedKeyset() throws Exception {
+    void typedKeyset() throws Exception {
         final TypedMap.Key<Double> ka = TypedMap.key("A", Double.class);
         final TypedMap.Key<String> kb = TypedMap.key("B", String.class);
         final TypedMap.Key<String> kc = TypedMap.key("C", String.class);
@@ -151,15 +145,15 @@ public class ImmutableTypedMapTest {
                 .build();
 
         Set<TypedMap.Key<String>> s = data.typedKeySet(String.class);
-        assertEquals("Typed set of keys has wrong size", 2, s.size());
-        assertFalse("Typed set of keys has unexpected member", s.contains(ka));
-        assertTrue("Typed set of keys is missing a key", s.contains(kb));
-        assertTrue("Typed set of keys is missing a key", s.contains(kc));
-        assertFalse("Typed set of keys has unexpected member", s.contains(kd));
+        assertEquals(2, s.size(), "Typed set of keys has wrong size");
+        assertFalse(s.contains(ka), "Typed set of keys has unexpected member");
+        assertTrue(s.contains(kb), "Typed set of keys is missing a key");
+        assertTrue(s.contains(kc), "Typed set of keys is missing a key");
+        assertFalse(s.contains(kd), "Typed set of keys has unexpected member");
     }
 
     @Test
-    public void iterator() throws Exception {
+    void iterator() throws Exception {
         final TypedMap.Key<Long> ka = TypedMap.key("1", Long.class);
         final TypedMap.Key<Short> kb = TypedMap.key("2", Short.class);
         final TypedMap.Key<BigInteger> kc = TypedMap.key("5", BigInteger.class);
@@ -192,25 +186,25 @@ public class ImmutableTypedMapTest {
                 seen_c = true;
             }
         }
-        assertEquals("Iterator iterated incorrect increments", 3, i);
-        assertTrue("Iterator missed an entry", seen_a);
-        assertTrue("Iterator missed an entry", seen_b);
-        assertTrue("Iterator missed an entry", seen_c);
+        assertEquals(3, i, "Iterator iterated incorrect increments");
+        assertTrue(seen_a, "Iterator missed an entry");
+        assertTrue(seen_b, "Iterator missed an entry");
+        assertTrue(seen_c, "Iterator missed an entry");
     }
 
-    @Test(expected=UnsupportedOperationException.class)
-    public void iterator_remove() throws Exception {
+    @Test
+    void iterator_remove() throws Exception {
         final TypedMap.Key<Long> ka = TypedMap.key("1", Long.class);
         final Long va = Long.valueOf(999999999);
 
         TypedMap data = ImmutableTypedMap.Builder.with(ka, va).build();
 
         Iterator<TypedMap.Entry> it = data.iterator();
-        it.remove();
+        assertThrows(UnsupportedOperationException.class, it::remove);
     }
 
     @Test
-    public void forEach() throws Exception {
+    void forEach() {
         final TypedMap.Key<Long> ka = TypedMap.key("1", Long.class);
         final TypedMap.Key<Short> kb = TypedMap.key("2", Short.class);
         final TypedMap.Key<BigInteger> kc = TypedMap.key("5", BigInteger.class);
@@ -242,14 +236,14 @@ public class ImmutableTypedMapTest {
                 seen[3] = true;
             }
         });
-        assertTrue("forEach missed an entry", seen[0]);
-        assertTrue("forEach missed an entry", seen[1]);
-        assertTrue("forEach missed an entry", seen[2]);
-        assertFalse("forEach hit an unexpected entry", seen[3]);
+        assertTrue(seen[0], "forEach missed an entry");
+        assertTrue(seen[1], "forEach missed an entry");
+        assertTrue(seen[2], "forEach missed an entry");
+        assertFalse(seen[3], "forEach hit an unexpected entry");
     }
 
     @Test
-    public void typedIterator() throws Exception {
+    void typedIterator() {
         final TypedMap.Key<String> ka = TypedMap.key("y", String.class);
         final TypedMap.Key<Object> kb = TypedMap.key("n", Object.class);
         final TypedMap.Key<String> kc = TypedMap.key("m", String.class);
@@ -287,26 +281,26 @@ public class ImmutableTypedMapTest {
                 seen_c = true;
             }
         }
-        assertEquals("Iterator iterated incorrect increments", 2, i);
-        assertTrue("Typed iterator missed an entry", seen_a);
-        assertFalse("Typed iterator returned an entry of wrong type", seen_b);
-        assertTrue("Typed iterator missed an entry", seen_c);
+        assertEquals(2, i, "Iterator iterated incorrect increments");
+        assertTrue(seen_a, "Typed iterator missed an entry");
+        assertFalse(seen_b, "Typed iterator returned an entry of wrong type");
+        assertTrue(seen_c, "Typed iterator missed an entry");
     }
 
-    @Test(expected=UnsupportedOperationException.class)
-    public void typedIterator_remove() throws Exception {
+    @Test
+    void typedIterator_remove() {
         final TypedMap.Key<String> ka = TypedMap.key("y", String.class);
         final String va = "yes";
 
         TypedMap data = ImmutableTypedMap.Builder.with(ka, va).build();
 
         Iterator<TypedMap.Entry<String>> it = data.typedIterator(String.class);
-        it.remove();
+        assertThrows(UnsupportedOperationException.class, it::remove);
     }
 
 
     @Test
-    public void forEachTyped() throws Exception {
+    void forEachTyped() {
         final TypedMap.Key<String> ka = TypedMap.key("y", String.class);
         final TypedMap.Key<Object> kb = TypedMap.key("n", Object.class);
         final TypedMap.Key<String> kc = TypedMap.key("m", String.class);
@@ -347,15 +341,15 @@ public class ImmutableTypedMapTest {
             }
         });
 
-        assertTrue("forEachTyped missed an entry", seen[0]);
-        assertFalse("forEachTyped hit an unexpected entry", seen[1]);
-        assertTrue("forEachTyped missed an entry", seen[2]);
-        assertFalse("forEachTyped hit an unexpected entry", seen[3]);
-        assertFalse("forEachTyped hit an unexpected entry", seen[4]);
+        assertTrue(seen[0], "forEachTyped missed an entry");
+        assertFalse(seen[1], "forEachTyped hit an unexpected entry");
+        assertTrue(seen[2], "forEachTyped missed an entry");
+        assertFalse(seen[3], "forEachTyped hit an unexpected entry");
+        assertFalse(seen[4], "forEachTyped hit an unexpected entry");
     }
 
     @Test
-    public void testMultipleBuildsDontMutateInstances() {
+    void testMultipleBuildsDontMutateInstances() {
         final TypedMap.Key<String> strKey = TypedMap.key("TestId1", String.class);
         final String foo = "FOO";
         final String bar = "BAR";


### PR DESCRIPTION
*Description of change*
Move from AWS SDK 1 to AWS SDK 2 and swap to JUnit 5.
AWS SDK 2 moves away from using the bundle of AWS SDKs for all AWS services.

There will be a breaking change for consumers of Swage Metrics Core, since AWS SDK 2 brings in different namespacing and a new CloudWatch client.  We're currently only doing a snapshot version so we didn't bump it to 1.0 or 2.0-SNAPSHOT.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
