### PR TITLE
Upgrade Junit5, Mockito4

### DIFF
--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -41,13 +41,15 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/StandardMetricTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/StandardMetricTest.java
@@ -14,9 +14,9 @@
  */
 package software.amazon.swage.metrics;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class StandardMetricTest {
+class StandardMetricTest {
 
     /*
      * Basic unit test to load the StandardMetric class and run validation on the
@@ -24,7 +24,7 @@ public class StandardMetricTest {
      * load/runtime.
      */
     @Test
-    public void validate() throws Exception {
+    void validate() {
         // Reference one member to force loading all static members.
         // Simpler than doing so explicitly ourselves.
         final Metric time = StandardMetric.TIME;

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/jmx/MXBeanPollerTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/jmx/MXBeanPollerTest.java
@@ -14,22 +14,21 @@
  */
 package software.amazon.swage.metrics.jmx;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-
-import org.junit.Test;
-
-import static org.junit.Assert.assertTrue;
-import org.mockito.ArgumentMatcher;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
 import software.amazon.swage.collection.TypedMap;
 import software.amazon.swage.metrics.MetricContext;
 import software.amazon.swage.metrics.StandardContext;
@@ -38,12 +37,14 @@ import software.amazon.swage.metrics.record.MetricRecorder;
 import software.amazon.swage.metrics.record.NullRecorder;
 
 /**
+ *
  */
-public class MXBeanPollerTest {
+class MXBeanPollerTest {
 
     // A matcher that checks the given TypedMap contains the minimal information
     // expected to be added by MXBeanPoller.
     private static final class DataMatcher implements ArgumentMatcher<TypedMap> {
+
         @Override
         public boolean matches(final TypedMap data) {
             if (!"JMX".equals(data.get(StandardContext.OPERATION))) {
@@ -55,7 +56,7 @@ public class MXBeanPollerTest {
     }
 
     @Test
-    public void senses() throws Exception {
+    void senses() throws Exception {
         final MetricRecorder recorder = new NullRecorder();
 
         final Sensor sensor1 = mock(Sensor.class);
@@ -79,12 +80,13 @@ public class MXBeanPollerTest {
     }
 
     @Test
-    public void shutdown() throws Exception {
+    void shutdown() {
         final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
-        MXBeanPoller poller = new MXBeanPoller(executor, new NullRecorder(), 5, Collections.emptyList());
+        MXBeanPoller poller = new MXBeanPoller(executor, new NullRecorder(), 5,
+                Collections.emptyList());
         poller.shutdown();
 
-        assertTrue("Executor not shutdown on poller shutdown", executor.isShutdown());
+        assertTrue(executor.isShutdown(), "Executor not shutdown on poller shutdown");
     }
 }

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorderTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/CloudWatchRecorderTest.java
@@ -14,34 +14,34 @@
  */
 package software.amazon.swage.metrics.record.cloudwatch;
 
-import software.amazon.swage.collection.TypedMap;
-import software.amazon.swage.metrics.ContextData;
-import software.amazon.swage.metrics.Metric;
-import software.amazon.swage.metrics.MetricContext;
-import software.amazon.swage.metrics.Unit;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
 import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
 import com.amazonaws.services.cloudwatch.model.StandardUnit;
 import com.amazonaws.services.cloudwatch.model.StatisticSet;
-import org.junit.Test;
-import org.mockito.ArgumentMatcher;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+import software.amazon.swage.collection.TypedMap;
+import software.amazon.swage.metrics.ContextData;
+import software.amazon.swage.metrics.Metric;
+import software.amazon.swage.metrics.MetricContext;
+import software.amazon.swage.metrics.Unit;
 
 
 /**
+ *
  */
-public class CloudWatchRecorderTest {
+class CloudWatchRecorderTest {
 
     private static final Metric M_TIME = Metric.define("Time");
     private static final Metric M_PERC = Metric.define("PercentSomething");
@@ -73,7 +73,8 @@ public class CloudWatchRecorderTest {
             for (MetricDatum actual : data) {
                 for (MetricDatum expected : this.metricData) {
                     // Ignore timestamps and compare the rest of the datum
-                    if (actual.clone().withTimestamp(null).equals(expected.clone().withTimestamp(null))) {
+                    if (actual.clone().withTimestamp(null)
+                            .equals(expected.clone().withTimestamp(null))) {
                         matches.add(expected);
                     }
                 }
@@ -84,7 +85,7 @@ public class CloudWatchRecorderTest {
     }
 
     @Test
-    public void record_and_shutdown() throws Exception {
+    void record_and_shutdown() {
         final DimensionMapper mapper = new DimensionMapper.Builder()
                 .addGlobalDimension(ContextData.ID)
                 .build();
@@ -120,7 +121,7 @@ public class CloudWatchRecorderTest {
 
 
     @Test
-    public void no_aggregation() throws Exception {
+    void no_aggregation() throws Exception {
         final DimensionMapper mapper = new DimensionMapper.Builder()
                 .addGlobalDimension(ContextData.ID)
                 .build();
@@ -168,7 +169,7 @@ public class CloudWatchRecorderTest {
     }
 
     @Test
-    public void aggregation() throws Exception {
+    void aggregation() throws Exception {
         final DimensionMapper mapper = new DimensionMapper.Builder()
                 .addGlobalDimension(ContextData.ID)
                 .build();
@@ -182,27 +183,26 @@ public class CloudWatchRecorderTest {
 
         final List<MetricDatum> expected = new ArrayList<>(3);
         expected.add(makeDatum(id,
-                               M_TIME.toString(),
-                               Arrays.stream(timeVals).sum(),
-                               Arrays.stream(timeVals).min().getAsDouble(),
-                               Arrays.stream(timeVals).max().getAsDouble(),
-                               timeVals.length,
-                               StandardUnit.Milliseconds));
+                M_TIME.toString(),
+                Arrays.stream(timeVals).sum(),
+                Arrays.stream(timeVals).min().getAsDouble(),
+                Arrays.stream(timeVals).max().getAsDouble(),
+                timeVals.length,
+                StandardUnit.Milliseconds));
         expected.add(makeDatum(id,
-                               M_PERC.toString(),
-                               Arrays.stream(percVals).sum(),
-                               Arrays.stream(percVals).min().getAsDouble(),
-                               Arrays.stream(percVals).max().getAsDouble(),
-                               percVals.length,
-                               StandardUnit.Percent));
+                M_PERC.toString(),
+                Arrays.stream(percVals).sum(),
+                Arrays.stream(percVals).min().getAsDouble(),
+                Arrays.stream(percVals).max().getAsDouble(),
+                percVals.length,
+                StandardUnit.Percent));
         expected.add(makeDatum(id,
-                               M_FAIL.toString(),
-                               Arrays.stream(failCnts).sum(),
-                               Arrays.stream(failCnts).min().getAsInt(),
-                               Arrays.stream(failCnts).max().getAsInt(),
-                               failCnts.length,
-                               StandardUnit.Count));
-
+                M_FAIL.toString(),
+                Arrays.stream(failCnts).sum(),
+                Arrays.stream(failCnts).min().getAsInt(),
+                Arrays.stream(failCnts).max().getAsInt(),
+                failCnts.length,
+                StandardUnit.Count));
 
         final AmazonCloudWatch client = mock(AmazonCloudWatch.class);
 
@@ -248,8 +248,7 @@ public class CloudWatchRecorderTest {
             final double min,
             final double max,
             final int count,
-            final StandardUnit unit)
-    {
+            final StandardUnit unit) {
         MetricDatum md = new MetricDatum().withMetricName(name).withUnit(unit);
 
         final StatisticSet statSet = new StatisticSet()
@@ -267,7 +266,5 @@ public class CloudWatchRecorderTest {
 
         return md;
     }
-
-
 
 }

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/DimensionMapperTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/DimensionMapperTest.java
@@ -14,27 +14,26 @@
  */
 package software.amazon.swage.metrics.record.cloudwatch;
 
-import com.amazonaws.services.cloudwatch.model.Dimension;
-import org.junit.Test;
-import software.amazon.swage.collection.TypedMap;
-import software.amazon.swage.metrics.ContextData;
-import software.amazon.swage.metrics.Metric;
-import software.amazon.swage.metrics.MetricContext;
-import software.amazon.swage.metrics.NullContext;
-import software.amazon.swage.metrics.StandardContext;
-import software.amazon.swage.metrics.record.MetricRecorder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
+import com.amazonaws.services.cloudwatch.model.Dimension;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Test;
+import software.amazon.swage.collection.TypedMap;
+import software.amazon.swage.metrics.ContextData;
+import software.amazon.swage.metrics.Metric;
+import software.amazon.swage.metrics.StandardContext;
+import software.amazon.swage.metrics.record.MetricRecorder;
 
 /**
+ *
  */
-public class DimensionMapperTest {
+class DimensionMapperTest {
+
     private static final Metric METRIC = Metric.define("FooMetric");
     private final String ID = UUID.randomUUID().toString();
     private final String SERVICE_NAME = UUID.randomUUID().toString();
@@ -43,35 +42,37 @@ public class DimensionMapperTest {
     private final String MARKETPLACE = UUID.randomUUID().toString();
 
     @Test
-    public void no_mappings() throws Exception {
-        MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(ContextData.withId(ID)
-                .add(StandardContext.SERVICE, SERVICE_NAME)
-                .build());
+    void no_mappings() {
+        MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(
+                ContextData.withId(ID)
+                        .add(StandardContext.SERVICE, SERVICE_NAME)
+                        .build());
 
         DimensionMapper mapper = new DimensionMapper.Builder().build();
 
-        assertTrue("Empty mapping resulted in non-empty dimension list",
-                   mapper.getDimensions(METRIC, context).isEmpty());
+        assertTrue(mapper.getDimensions(METRIC, context).isEmpty(),
+                "Empty mapping resulted in non-empty dimension list");
     }
 
     @Test
-    public void one_global() throws Exception {
-        MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(ContextData.withId(ID)
-                                      .add(StandardContext.SERVICE, SERVICE_NAME)
-                                      .build());
+    void one_global() {
+        MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(
+                ContextData.withId(ID)
+                        .add(StandardContext.SERVICE, SERVICE_NAME)
+                        .build());
 
         DimensionMapper mapper = new DimensionMapper.Builder()
                 .addGlobalDimension(ContextData.ID)
                 .build();
 
         List<Dimension> dims = mapper.getDimensions(METRIC, context);
-        assertEquals("Unexpected size of dimension list", 1, dims.size());
-        assertEquals("Unexpected name for dimension", ContextData.ID.name, dims.get(0).getName());
-        assertEquals("Unexpected value for dimension", ID, dims.get(0).getValue());
+        assertEquals(1, dims.size(), "Unexpected size of dimension list");
+        assertEquals(ContextData.ID.name, dims.get(0).getName(), "Unexpected name for dimension");
+        assertEquals(ID, dims.get(0).getValue(), "Unexpected value for dimension");
     }
 
     @Test
-    public void one_global_empty_context() throws Exception {
+    void one_global_empty_context() {
         MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(TypedMap.empty());
 
         DimensionMapper mapper = new DimensionMapper.Builder()
@@ -79,42 +80,47 @@ public class DimensionMapperTest {
                 .build();
 
         List<Dimension> dims = mapper.getDimensions(METRIC, context);
-        assertEquals("Unexpected size of dimension list", 1, dims.size());
-        assertEquals("Unexpected name for dimension", ContextData.ID.name, dims.get(0).getName());
-        assertEquals("Unexpected value for missing dimension", "null", dims.get(0).getValue());
+        assertEquals(1, dims.size(), "Unexpected size of dimension list");
+        assertEquals(ContextData.ID.name, dims.get(0).getName(), "Unexpected name for dimension");
+        assertEquals("null", dims.get(0).getValue(), "Unexpected value for missing dimension");
     }
 
     @Test
-    public void global_and_normal_dimensions_combine() throws Exception {
-        MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(ContextData.withId(ID)
-                                      .add(StandardContext.SERVICE, SERVICE_NAME)
-                                      .build());
+    void global_and_normal_dimensions_combine() {
+        MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(
+                ContextData.withId(ID)
+                        .add(StandardContext.SERVICE, SERVICE_NAME)
+                        .build());
 
         DimensionMapper mapper = new DimensionMapper.Builder()
                 .addGlobalDimension(ContextData.ID)
                 .addMetric(METRIC, Arrays.asList(StandardContext.SERVICE))
                 .build();
         Dimension expectedIdDimension = new Dimension().withName(ContextData.ID.name).withValue(ID);
-        Dimension expectedServiceDimension = new Dimension().withName(StandardContext.SERVICE.name).withValue(SERVICE_NAME);
+        Dimension expectedServiceDimension = new Dimension().withName(StandardContext.SERVICE.name)
+                .withValue(SERVICE_NAME);
 
         List<Dimension> dims = mapper.getDimensions(METRIC, context);
-        assertTrue("Dimension list is missing mapped ID dimension", dims.contains(expectedIdDimension));
-        assertTrue("Dimension list is missing mapped SERVICE dimension", dims.contains(expectedServiceDimension));
-        assertEquals("Unexpected size of dimension list", 2, dims.size());
+        assertTrue(dims.contains(expectedIdDimension),
+                "Dimension list is missing mapped ID dimension");
+        assertTrue(dims.contains(expectedServiceDimension),
+                "Dimension list is missing mapped SERVICE dimension");
+        assertEquals(2, dims.size(), "Unexpected size of dimension list");
     }
 
     @Test
-    public void mappings() throws Exception {
+    void mappings() {
         Metric metricA = Metric.define("Alpha");
         Metric metricB = Metric.define("Beta");
         Metric metricC = Metric.define("Gamma");
 
         String operation = "doStuff";
 
-        MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(ContextData.withId(ID)
-                                      .add(StandardContext.SERVICE, SERVICE_NAME)
-                                      .add(StandardContext.OPERATION, operation)
-                                      .build());
+        MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(
+                ContextData.withId(ID)
+                        .add(StandardContext.SERVICE, SERVICE_NAME)
+                        .add(StandardContext.OPERATION, operation)
+                        .build());
 
         DimensionMapper mapper = new DimensionMapper.Builder()
                 .addMetric(metricA, Arrays.asList(StandardContext.SERVICE))
@@ -123,59 +129,55 @@ public class DimensionMapperTest {
                 .build();
 
         List<Dimension> dimsA = mapper.getDimensions(metricA, context);
-        assertEquals("Unexpected size of dimension list", 1, dimsA.size());
-        assertEquals("Unexpected name for dimension", StandardContext.SERVICE.name, dimsA.get(0).getName());
-        assertEquals("Unexpected value for dimension", SERVICE_NAME, dimsA.get(0).getValue());
-
+        assertEquals(1, dimsA.size(), "Unexpected size of dimension list");
+        assertEquals(StandardContext.SERVICE.name, dimsA.get(0).getName(),
+                "Unexpected name for dimension");
+        assertEquals(SERVICE_NAME, dimsA.get(0).getValue(), "Unexpected value for dimension");
 
         List<Dimension> dimsB = mapper.getDimensions(metricB, context);
-        assertEquals("Unexpected size of dimension list", 2, dimsB.size());
+        assertEquals(2, dimsB.size(), "Unexpected size of dimension list");
         boolean seenB[] = {false, false};
         for (Dimension d : dimsB) {
             if (d.getName().equals(StandardContext.SERVICE.name) &&
                     d.getValue().equals(SERVICE_NAME)) {
                 seenB[0] = true;
-            }
-            else if (d.getName().equals(StandardContext.OPERATION.name) &&
-                d.getValue().equals(operation)) {
+            } else if (d.getName().equals(StandardContext.OPERATION.name) &&
+                    d.getValue().equals(operation)) {
                 seenB[1] = true;
-            }
-            else {
+            } else {
                 fail("Unexpected dimension present in mapped list");
             }
         }
-        assertTrue("Dimension list is missing mapped SERVICE dimension", seenB[0]);
-        assertTrue("Dimension list is missing mapped OPERATION dimension", seenB[1]);
-
+        assertTrue(seenB[0], "Dimension list is missing mapped SERVICE dimension");
+        assertTrue(seenB[1], "Dimension list is missing mapped OPERATION dimension");
 
         List<Dimension> dimsC = mapper.getDimensions(metricC, context);
-        assertEquals("Unexpected size of dimension list", 2, dimsC.size());
+        assertEquals(2, dimsC.size(), "Unexpected size of dimension list");
         boolean seenC[] = {false, false};
         for (Dimension d : dimsC) {
             if (d.getName().equals(StandardContext.SERVICE.name) &&
-                d.getValue().equals(SERVICE_NAME)) {
+                    d.getValue().equals(SERVICE_NAME)) {
                 seenC[0] = true;
-            }
-            else if (d.getName().equals(StandardContext.ID.name) &&
-                     d.getValue().equals(ID)) {
+            } else if (d.getName().equals(StandardContext.ID.name) &&
+                    d.getValue().equals(ID)) {
                 seenC[1] = true;
-            }
-            else {
+            } else {
                 fail("Unexpected dimension present in mapped list");
             }
         }
-        assertTrue("Dimension list is missing mapped SERVICE dimension", seenC[0]);
-        assertTrue("Dimension list is missing mapped ID dimension", seenC[1]);
+        assertTrue(seenC[0], "Dimension list is missing mapped SERVICE dimension");
+        assertTrue(seenC[1], "Dimension list is missing mapped ID dimension");
     }
 
     @Test
-    public void attributes_are_sorted() throws Exception {
-        MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(ContextData.withId(ID)
-                .add(StandardContext.SERVICE, SERVICE_NAME)
-                .add(StandardContext.OPERATION, OPERATION)
-                .add(StandardContext.MARKETPLACE, MARKETPLACE)
-                .add(StandardContext.PROGRAM, PROGRAM)
-                .build());
+    void attributes_are_sorted() {
+        MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(
+                ContextData.withId(ID)
+                        .add(StandardContext.SERVICE, SERVICE_NAME)
+                        .add(StandardContext.OPERATION, OPERATION)
+                        .add(StandardContext.MARKETPLACE, MARKETPLACE)
+                        .add(StandardContext.PROGRAM, PROGRAM)
+                        .build());
 
         DimensionMapper mapper = new DimensionMapper.Builder()
                 .addGlobalDimension(ContextData.ID)
@@ -186,10 +188,14 @@ public class DimensionMapperTest {
                 .build();
 
         Dimension expectedIdDimension = new Dimension().withName(ContextData.ID.name).withValue(ID);
-        Dimension expectedServiceDimension = new Dimension().withName(StandardContext.SERVICE.name).withValue(SERVICE_NAME);
-        Dimension expectedOperationDimension = new Dimension().withName(StandardContext.OPERATION.name).withValue(OPERATION);
-        Dimension expectedMarketplaceDimension = new Dimension().withName(StandardContext.MARKETPLACE.name).withValue(MARKETPLACE);
-        Dimension expectedProgramDimension = new Dimension().withName(StandardContext.PROGRAM.name).withValue(PROGRAM);
+        Dimension expectedServiceDimension = new Dimension().withName(StandardContext.SERVICE.name)
+                .withValue(SERVICE_NAME);
+        Dimension expectedOperationDimension = new Dimension().withName(
+                StandardContext.OPERATION.name).withValue(OPERATION);
+        Dimension expectedMarketplaceDimension = new Dimension().withName(
+                StandardContext.MARKETPLACE.name).withValue(MARKETPLACE);
+        Dimension expectedProgramDimension = new Dimension().withName(StandardContext.PROGRAM.name)
+                .withValue(PROGRAM);
         List<Dimension> expected = Arrays.asList(expectedIdDimension,
                 expectedMarketplaceDimension,
                 expectedOperationDimension,
@@ -201,11 +207,12 @@ public class DimensionMapperTest {
     }
 
     @Test
-    public void parent_and_child_attributes_combine() throws Exception {
+    void parent_and_child_attributes_combine() {
         String childId = UUID.randomUUID().toString();
-        MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(ContextData.withId(ID)
-                                      .add(StandardContext.SERVICE, SERVICE_NAME)
-                                      .build());
+        MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(
+                ContextData.withId(ID)
+                        .add(StandardContext.SERVICE, SERVICE_NAME)
+                        .build());
 
         MetricRecorder.RecorderContext childContext = context.newChild(ContextData.withId(childId)
                 .add(StandardContext.OPERATION, OPERATION)
@@ -216,9 +223,12 @@ public class DimensionMapperTest {
                 .addMetric(METRIC, Arrays.asList(StandardContext.SERVICE, StandardContext.OPERATION))
                 .build();
 
-        Dimension expectedIdDimension = new Dimension().withName(ContextData.ID.name).withValue(childId);
-        Dimension expectedServiceDimension = new Dimension().withName(StandardContext.SERVICE.name).withValue(SERVICE_NAME);
-        Dimension expectedOperationDimension = new Dimension().withName(StandardContext.OPERATION.name).withValue(OPERATION);
+        Dimension expectedIdDimension = new Dimension().withName(ContextData.ID.name)
+                .withValue(childId);
+        Dimension expectedServiceDimension = new Dimension().withName(StandardContext.SERVICE.name)
+                .withValue(SERVICE_NAME);
+        Dimension expectedOperationDimension = new Dimension().withName(
+                StandardContext.OPERATION.name).withValue(OPERATION);
         List<Dimension> expected = Arrays.asList(expectedIdDimension,
                 expectedOperationDimension,
                 expectedServiceDimension);
@@ -228,14 +238,15 @@ public class DimensionMapperTest {
     }
 
     @Test
-    public void child_attributes_override_parent() throws Exception {
+    void child_attributes_override_parent() {
         String childId = UUID.randomUUID().toString();
         String childService = UUID.randomUUID().toString();
         String childOperation = UUID.randomUUID().toString();
-        MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(ContextData.withId(ID)
-                                      .add(StandardContext.SERVICE, SERVICE_NAME)
-                                      .add(StandardContext.OPERATION, OPERATION)
-                                      .build());
+        MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(
+                ContextData.withId(ID)
+                        .add(StandardContext.SERVICE, SERVICE_NAME)
+                        .add(StandardContext.OPERATION, OPERATION)
+                        .build());
 
         MetricRecorder.RecorderContext childContext = context.newChild(ContextData.withId(childId)
                 .add(StandardContext.SERVICE, childService)
@@ -247,9 +258,12 @@ public class DimensionMapperTest {
                 .addMetric(METRIC, Arrays.asList(StandardContext.SERVICE, StandardContext.OPERATION))
                 .build();
 
-        Dimension expectedIdDimension = new Dimension().withName(ContextData.ID.name).withValue(childId);
-        Dimension expectedServiceDimension = new Dimension().withName(StandardContext.SERVICE.name).withValue(childService);
-        Dimension expectedOperationDimension = new Dimension().withName(StandardContext.OPERATION.name).withValue(childOperation);
+        Dimension expectedIdDimension = new Dimension().withName(ContextData.ID.name)
+                .withValue(childId);
+        Dimension expectedServiceDimension = new Dimension().withName(StandardContext.SERVICE.name)
+                .withValue(childService);
+        Dimension expectedOperationDimension = new Dimension().withName(StandardContext.OPERATION.name)
+                .withValue(childOperation);
         List<Dimension> expected = Arrays.asList(expectedIdDimension,
                 expectedOperationDimension,
                 expectedServiceDimension);

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/MetricDataAggregatorTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/record/cloudwatch/MetricDataAggregatorTest.java
@@ -14,22 +14,21 @@
  */
 package software.amazon.swage.metrics.record.cloudwatch;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import com.amazonaws.services.cloudwatch.model.StandardUnit;
 import com.amazonaws.services.cloudwatch.model.StatisticSet;
-import org.junit.Test;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
 import software.amazon.swage.metrics.ContextData;
 import software.amazon.swage.metrics.Metric;
 import software.amazon.swage.metrics.record.MetricRecorder;
 
-import java.util.List;
-import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-public class MetricDataAggregatorTest {
+class MetricDataAggregatorTest {
 
     private static final Metric A = Metric.define("A");
     private static final Metric B = Metric.define("B");
@@ -37,7 +36,7 @@ public class MetricDataAggregatorTest {
     private static final Metric D = Metric.define("D");
 
     @Test
-    public void single() throws Exception {
+    void single() {
         final DimensionMapper mapper = new DimensionMapper.Builder()
                 .addGlobalDimension(ContextData.ID)
                 .build();
@@ -46,69 +45,79 @@ public class MetricDataAggregatorTest {
         final double value = 3.14;
         final StandardUnit unit = StandardUnit.Terabits;
 
-        final MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(ContextData.withId(UUID.randomUUID().toString()).build());
+        final MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(
+                ContextData.withId(UUID.randomUUID().toString()).build());
 
         MetricDataAggregator aggregator = new MetricDataAggregator(mapper);
         aggregator.add(context, name, value, unit);
 
         List<MetricDatum> ags = aggregator.flush();
 
-        assertEquals("One metric datum should aggregate to one entry", 1, ags.size());
-        assertEquals("Metric datum has wrong name", name.toString(), ags.get(0).getMetricName());
-        assertEquals("Metric datum has wrong unit", unit.toString(), ags.get(0).getUnit());
+        assertEquals(1, ags.size(), "One metric datum should aggregate to one entry");
+        assertEquals(name.toString(), ags.get(0).getMetricName(), "Metric datum has wrong name");
+        assertEquals(unit.toString(), ags.get(0).getUnit(), "Metric datum has wrong unit");
 
         StatisticSet stats = ags.get(0).getStatisticValues();
-        assertEquals("Metric datum has wrong stats value", Double.valueOf(value), stats.getSum());
-        assertEquals("Metric datum has wrong stats value", Double.valueOf(value), stats.getMinimum());
-        assertEquals("Metric datum has wrong stats value", Double.valueOf(value), stats.getMaximum());
-        assertEquals("Metric datum has wrong stats count", Double.valueOf(1), stats.getSampleCount());
+        assertEquals(Double.valueOf(value), stats.getSum(), "Metric datum has wrong stats value");
+        assertEquals(Double.valueOf(value), stats.getMinimum(),
+                "Metric datum has wrong stats value");
+        assertEquals(Double.valueOf(value), stats.getMaximum(),
+                "Metric datum has wrong stats value");
+        assertEquals(Double.valueOf(1), stats.getSampleCount(),
+                "Metric datum has wrong stats count");
 
-        assertTrue("Flush with no attributes was non-empty", aggregator.flush().isEmpty());
+        assertTrue(aggregator.flush().isEmpty(), "Flush with no attributes was non-empty");
     }
 
 
     @Test
-    public void non_aggregated() throws Exception {
+    void non_aggregated() {
         final DimensionMapper mapper = new DimensionMapper.Builder()
                 .addGlobalDimension(ContextData.ID)
                 .build();
 
         final Metric[] names = {A, B, C, D};
         final double[] values = {3.14, 6.28, 0, 9};
-        final StandardUnit[] units = {StandardUnit.Seconds, StandardUnit.Terabits, StandardUnit.Seconds, StandardUnit.Milliseconds};
+        final StandardUnit[] units = {StandardUnit.Seconds, StandardUnit.Terabits,
+                StandardUnit.Seconds, StandardUnit.Milliseconds};
 
-        final MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(ContextData.withId(UUID.randomUUID().toString()).build());
+        final MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(
+                ContextData.withId(UUID.randomUUID().toString()).build());
 
         MetricDataAggregator aggregator = new MetricDataAggregator(mapper);
-        for (int i=0; i<names.length; i++) {
+        for (int i = 0; i < names.length; i++) {
             aggregator.add(context, names[i], values[i], units[i]);
         }
 
         List<MetricDatum> ags = aggregator.flush();
 
-        assertEquals("Metric attributes hs wrong size", names.length, ags.size());
+        assertEquals(names.length, ags.size(), "Metric attributes hs wrong size");
         for (MetricDatum d : ags) {
             int i = 0;
             while (i < names.length && !names[i].toString().equals(d.getMetricName())) {
                 i++;
             }
-            assertTrue("Aggregated metrics had unexpected datum", i<names.length);
+            assertTrue(i < names.length, "Aggregated metrics had unexpected datum");
 
-            assertEquals("Metric datum has wrong name", names[i].toString(), d.getMetricName());
-            assertEquals("Metric datum has wrong unit", units[i].toString(), d.getUnit());
+            assertEquals(names[i].toString(), d.getMetricName(), "Metric datum has wrong name");
+            assertEquals(units[i].toString(), d.getUnit(), "Metric datum has wrong unit");
 
             StatisticSet stats = d.getStatisticValues();
-            assertEquals("Metric datum has wrong stats value", Double.valueOf(values[i]), stats.getSum());
-            assertEquals("Metric datum has wrong stats value", Double.valueOf(values[i]), stats.getMinimum());
-            assertEquals("Metric datum has wrong stats value", Double.valueOf(values[i]), stats.getMaximum());
-            assertEquals("Metric datum has wrong stats count", Double.valueOf(1), stats.getSampleCount());
+            assertEquals(Double.valueOf(values[i]), stats.getSum(),
+                    "Metric datum has wrong stats value");
+            assertEquals(Double.valueOf(values[i]), stats.getMinimum(),
+                    "Metric datum has wrong stats value");
+            assertEquals(Double.valueOf(values[i]), stats.getMaximum(),
+                    "Metric datum has wrong stats value");
+            assertEquals(Double.valueOf(1), stats.getSampleCount(),
+                    "Metric datum has wrong stats count");
         }
 
-        assertTrue("Flush with no attributes was non-empty", aggregator.flush().isEmpty());
+        assertTrue(aggregator.flush().isEmpty(), "Flush with no attributes was non-empty");
     }
 
     @Test
-    public void aggregate() throws Exception {
+    void aggregate() {
         final DimensionMapper mapper = new DimensionMapper.Builder()
                 .addGlobalDimension(ContextData.ID)
                 .build();
@@ -124,101 +133,126 @@ public class MetricDataAggregatorTest {
                 StandardUnit.Percent,
                 StandardUnit.Milliseconds};
 
-        final MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(ContextData.withId(UUID.randomUUID().toString()).build());
+        final MetricRecorder.RecorderContext context = new MetricRecorder.RecorderContext(
+                ContextData.withId(UUID.randomUUID().toString()).build());
 
         MetricDataAggregator aggregator = new MetricDataAggregator(mapper);
-        for (int i=0; i<names.length; i++) {
+        for (int i = 0; i < names.length; i++) {
             aggregator.add(context, names[i], values[i], units[i]);
         }
 
         List<MetricDatum> ags = aggregator.flush();
 
-        assertEquals("Metric attributes hs wrong size", 4, ags.size());
+        assertEquals(4, ags.size(), "Metric attributes hs wrong size");
         boolean[] seen = {false, false, false, false};
         for (MetricDatum d : ags) {
-            if (d.getMetricName().equals(A.toString()) && d.getUnit().equals(StandardUnit.Seconds.toString())) {
+            if (d.getMetricName().equals(A.toString()) && d.getUnit()
+                    .equals(StandardUnit.Seconds.toString())) {
                 StatisticSet stats = d.getStatisticValues();
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(3.14+0), stats.getSum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(0), stats.getMinimum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(3.14), stats.getMaximum());
-                assertEquals("Aggregated metric has wrong stats count", Double.valueOf(2), stats.getSampleCount());
+                assertEquals(Double.valueOf(3.14 + 0), stats.getSum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(0), stats.getMinimum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(3.14), stats.getMaximum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(2), stats.getSampleCount(),
+                        "Aggregated metric has wrong stats value");
                 seen[0] = true;
-            }
-            else if (d.getMetricName().equals(B.toString()) && d.getUnit().equals(StandardUnit.Terabits.toString())) {
+            } else if (d.getMetricName().equals(B.toString()) && d.getUnit()
+                    .equals(StandardUnit.Terabits.toString())) {
                 StatisticSet stats = d.getStatisticValues();
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(6.28), stats.getSum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(6.28), stats.getMinimum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(6.28), stats.getMaximum());
-                assertEquals("Aggregated metric has wrong stats count", Double.valueOf(1), stats.getSampleCount());
+                assertEquals(Double.valueOf(6.28), stats.getSum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(6.28), stats.getMinimum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(6.28), stats.getMaximum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(1), stats.getSampleCount(),
+                        "Aggregated metric has wrong stats count");
                 seen[1] = true;
-            }
-            else if (d.getMetricName().equals(D.toString()) && d.getUnit().equals(StandardUnit.Milliseconds.toString())) {
+            } else if (d.getMetricName().equals(D.toString()) && d.getUnit()
+                    .equals(StandardUnit.Milliseconds.toString())) {
                 StatisticSet stats = d.getStatisticValues();
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(42+9+4.1), stats.getSum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(4.1), stats.getMinimum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(42), stats.getMaximum());
-                assertEquals("Aggregated metric has wrong stats count", Double.valueOf(3), stats.getSampleCount());
+                assertEquals(Double.valueOf(42 + 9 + 4.1), stats.getSum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(4.1), stats.getMinimum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(42), stats.getMaximum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(3), stats.getSampleCount(),
+                        "Aggregated metric has wrong stats count");
                 seen[2] = true;
-            }
-            else if (d.getMetricName().equals(D.toString()) && d.getUnit().equals(StandardUnit.Percent.toString())) {
+            } else if (d.getMetricName().equals(D.toString()) && d.getUnit()
+                    .equals(StandardUnit.Percent.toString())) {
                 StatisticSet stats = d.getStatisticValues();
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(2), stats.getSum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(2), stats.getMinimum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(2), stats.getMaximum());
-                assertEquals("Aggregated metric has wrong stats count", Double.valueOf(1), stats.getSampleCount());
+                assertEquals(Double.valueOf(2), stats.getSum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(2), stats.getMinimum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(2), stats.getMaximum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(1), stats.getSampleCount(),
+                        "Aggregated metric has wrong stats count");
                 seen[3] = true;
-            }
-            else {
+            } else {
                 fail("Unexpected metric returned in aggregated set");
             }
         }
-        for (int i=0; i<seen.length; i++) {
-            assertTrue("Expected aggregated metric not seen", seen[i]);
+        for (int i = 0; i < seen.length; i++) {
+            assertTrue(seen[i], "Expected aggregated metric not seen");
         }
 
-        assertTrue("Flush with no attributes was non-empty", aggregator.flush().isEmpty());
+        assertTrue(aggregator.flush().isEmpty(), "Flush with no attributes was non-empty");
 
         // Now add more attributes, but let's just do two this time
-        for (int i=0; i<5; i++) {
+        for (int i = 0; i < 5; i++) {
             aggregator.add(context, A, i, StandardUnit.Count);
         }
         Metric other = Metric.define("Other");
         double osum = 0;
-        for (int i=0; i<12; i++) {
-            osum += 0.01*i;
-            aggregator.add(context, other, 0.01*i, StandardUnit.Terabits);
+        for (int i = 0; i < 12; i++) {
+            osum += 0.01 * i;
+            aggregator.add(context, other, 0.01 * i, StandardUnit.Terabits);
         }
 
         ags = aggregator.flush();
 
-        assertEquals("Metric attributes hs wrong size", 2, ags.size());
+        assertEquals(2, ags.size(), "Metric attributes hs wrong size");
         boolean seenA = false;
         boolean seenO = false;
         for (MetricDatum d : ags) {
-            if (d.getMetricName().equals(A.toString()) && d.getUnit().equals(StandardUnit.Count.toString())) {
+            if (d.getMetricName().equals(A.toString()) && d.getUnit()
+                    .equals(StandardUnit.Count.toString())) {
                 StatisticSet stats = d.getStatisticValues();
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(0+1+2+3+4), stats.getSum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(0), stats.getMinimum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(4), stats.getMaximum());
-                assertEquals("Aggregated metric has wrong stats count", Double.valueOf(5), stats.getSampleCount());
+                assertEquals(Double.valueOf(0 + 1 + 2 + 3 + 4), stats.getSum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(0), stats.getMinimum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(4), stats.getMaximum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(5), stats.getSampleCount(),
+                        "Aggregated metric has wrong stats count");
                 seenA = true;
-            }
-            else if (d.getMetricName().equals(other.toString()) && d.getUnit().equals(StandardUnit.Terabits.toString())) {
+            } else if (d.getMetricName().equals(other.toString()) && d.getUnit()
+                    .equals(StandardUnit.Terabits.toString())) {
                 StatisticSet stats = d.getStatisticValues();
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(osum), stats.getSum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(0), stats.getMinimum());
-                assertEquals("Aggregated metric has wrong stats value", Double.valueOf(0.11), stats.getMaximum());
-                assertEquals("Aggregated metric has wrong stats count", Double.valueOf(12), stats.getSampleCount());
+                assertEquals(Double.valueOf(osum), stats.getSum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(0), stats.getMinimum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(0.11), stats.getMaximum(),
+                        "Aggregated metric has wrong stats value");
+                assertEquals(Double.valueOf(12), stats.getSampleCount(),
+                        "Aggregated metric has wrong stats count");
                 seenO = true;
-            }
-            else {
+            } else {
                 fail("Unexpected metric returned in aggregated set");
             }
         }
-        assertTrue("Expected aggregated metric not seen", seenA);
-        assertTrue("Expected aggregated metric not seen", seenO);
+        assertTrue(seenA, "Expected aggregated metric not seen");
+        assertTrue(seenO, "Expected aggregated metric not seen");
 
-        assertTrue("Flush with no attributes was non-empty", aggregator.flush().isEmpty());
+        assertTrue(aggregator.flush().isEmpty(), "Flush with no attributes was non-empty");
     }
 
 }

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/record/file/FileRecorderTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/record/file/FileRecorderTest.java
@@ -1,38 +1,38 @@
 package software.amazon.swage.metrics.record.file;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Test;
 import software.amazon.swage.metrics.Metric;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+class FileRecorderTest {
 
-public class FileRecorderTest {
     @Test
-    public void validation() {
+    void validation() {
         final String[] good = {
-            "snake_case_metric",
-            "camelCaseMetric",
-            "hyphenated-metric",
-            "spaced out metric",
-            "digits 0123456789",
-            "G\u00FCnther",
-            // All of the bad-idea characters that are allowed (and not above)
-            "\t!\"#$%&'()*+./;<>?@[\\]^`{|}~" // no ',' ':' '\n'
+                "snake_case_metric",
+                "camelCaseMetric",
+                "hyphenated-metric",
+                "spaced out metric",
+                "digits 0123456789",
+                "G\u00FCnther",
+                // All of the bad-idea characters that are allowed (and not above)
+                "\t!\"#$%&'()*+./;<>?@[\\]^`{|}~" // no ',' ':' '\n'
         };
         for (final String s : good) {
-            assertTrue("valid name [" + s + "]", FileRecorder.isValid(Metric.define(s)));
+            assertTrue(FileRecorder.isValid(Metric.define(s)), "valid name [" + s + "]");
         }
 
         final String[] bad = {
-            // Each case demonstrates one form of ambiguity:
-            "metric_name, dimension=value",
-            "metric_name:100ms:",
-            "metric_name\nmetric",
-            "metric=metric_name"
+                // Each case demonstrates one form of ambiguity:
+                "metric_name, dimension=value",
+                "metric_name:100ms:",
+                "metric_name\nmetric",
+                "metric=metric_name"
         };
         for (final String s : bad) {
-            assertFalse("invalid name [" + s + "]", FileRecorder.isValid(Metric.define(s)));
+            assertFalse(FileRecorder.isValid(Metric.define(s)), "invalid name [" + s + "]");
         }
     }
 }

--- a/metrics-core/src/test/java/software/amazon/swage/metrics/record/file/RollingFileWriterTest.java
+++ b/metrics-core/src/test/java/software/amazon/swage/metrics/record/file/RollingFileWriterTest.java
@@ -14,7 +14,9 @@
  */
 package software.amazon.swage.metrics.record.file;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -24,21 +26,20 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.TimeZone;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the RollingFileWriter.
- *
- * Requires the "test.area" system property to be set, specifying directory
- * where temporary log files will be created.
- *
+ * <p>
+ * Requires the "test.area" system property to be set, specifying directory where temporary log
+ * files will be created.
+ * <p>
  * TODO: more/robust tests, you know, like actual log rolling
  */
-public class RollingFileWriterTest {
+class RollingFileWriterTest {
 
     private static final Path testDir;
+
     static {
         String testProp = System.getProperty("test.area");
         if (testProp == null || testProp.isEmpty()) {
@@ -50,32 +51,41 @@ public class RollingFileWriterTest {
     private String currentHourExt(TimeZone tz) {
         return DateTimeFormatter
                 .ofPattern(".yyyy-MM-dd-HH")
-                .format(LocalDateTime.ofInstant(Instant.now().truncatedTo(ChronoUnit.HOURS), tz.toZoneId()));
+                .format(LocalDateTime.ofInstant(Instant.now().truncatedTo(ChronoUnit.HOURS),
+                        tz.toZoneId()));
     }
+
     private String currentMinExt(TimeZone tz) {
         return DateTimeFormatter
                 .ofPattern(".yyyy-MM-dd-HH-mm")
-                .format(LocalDateTime.ofInstant(Instant.now().truncatedTo(ChronoUnit.MINUTES), tz.toZoneId()));
+                .format(LocalDateTime.ofInstant(Instant.now().truncatedTo(ChronoUnit.MINUTES),
+                        tz.toZoneId()));
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void nullDir() throws Exception {
-        new RollingFileWriter(null, "foo");
+    @Test
+    void nullDir() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RollingFileWriter(null, "foo");
+        });
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void nullName() throws Exception {
-        new RollingFileWriter(testDir, null);
+    @Test
+    void nullName() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RollingFileWriter(testDir, null);
+        });
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void nullZone() throws Exception {
-        new RollingFileWriter(testDir, "bar", null, false);
+    @Test
+    void nullZone() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RollingFileWriter(testDir, "bar", null, false);
+        });
     }
 
 
     @Test
-    public void filenameUTC() throws Exception {
+    void filenameUTC() throws Exception {
         final String base = "test";
 
         // Current rolled file for the current hour
@@ -97,7 +107,7 @@ public class RollingFileWriterTest {
     }
 
     @Test
-    public void filenameLocalZone() throws Exception {
+    void filenameLocalZone() throws Exception {
         final TimeZone tz = TimeZone.getDefault();
         final String base = "what";
 
@@ -111,7 +121,7 @@ public class RollingFileWriterTest {
     }
 
     @Test
-    public void filenameMinute() throws Exception {
+    void filenameMinute() throws Exception {
         final TimeZone tz = TimeZone.getTimeZone("UTC");
         final String base = "mins";
 
@@ -126,16 +136,16 @@ public class RollingFileWriterTest {
         // Just in case minute rolled during test, check before and after minutes
         Path p = w.getCurrentFile();
         assertTrue(p.equals(expected) ||
-                   p.equals(testDir.resolve(base + currentMinExt(tz))));
+                p.equals(testDir.resolve(base + currentMinExt(tz))));
     }
 
     @Test
-    public void createDirectory() throws Exception {
+    void createDirectory() throws Exception {
         // Create a unique non-existent file path
         Path path;
         do {
-            path = testDir.resolve("a/b/"+System.currentTimeMillis());
-        } while(Files.exists(path));
+            path = testDir.resolve("a/b/" + System.currentTimeMillis());
+        } while (Files.exists(path));
 
         RollingFileWriter w = new RollingFileWriter(path, "test");
         w.write("stuff here");


### PR DESCRIPTION
I'm going to start changing the aggregator logic to increase its TPS into the aggregation logic, but before I do that I want to upgrade the unit testing frameworks.

*Description of changes:*
Migrating from JUnit4 to JUnit5, including:
1. Removing all `public` keywords from tests and methods
2. Replacing JUnit4 annotations with their equivalents in JUnit5
3. Swapping error strings due to API change in JUnit 5.  In JUnit4, the error message was the first parameter, in JUnit5 the error message was the second.
4. There's a bunch of formatting changes, mostly around making spaces consistent across the files.

See: https://junit.org/junit5/docs/current/user-guide/#migrating-from-junit4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
